### PR TITLE
Feat/layout UI changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react-dom": "^19.1.1",
         "react-hot-toast": "^2.6.0",
         "react-router": "^7.8.2",
+        "react-tooltip": "^5.29.1",
         "tailwindcss": "^4.1.8",
         "vite-plugin-top-level-await": "^1.6.0",
         "zustand": "^5.0.8"
@@ -1155,6 +1156,31 @@
         "vm-browserify": "^1.1.2",
         "webtorrent": "^2.5.7"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
+      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
     },
     "node_modules/@harmoniclabs/bigint-utils": {
       "version": "1.0.0",
@@ -3661,19 +3687,6 @@
         }
       }
     },
-    "node_modules/@vitest/pretty-format": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
-      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^1.2.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "node_modules/@vitest/runner": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
@@ -3857,21 +3870,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@vitest/utils": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
-      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "2.1.9",
-        "loupe": "^3.1.2",
-        "tinyrainbow": "^1.2.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@webtorrent/http-node": {
@@ -5413,6 +5411,12 @@
       "dependencies": {
         "block-iterator": "^1.1.1"
       }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
     },
     "node_modules/clone-response": {
       "version": "1.0.2",
@@ -11674,6 +11678,20 @@
         }
       }
     },
+    "node_modules/react-tooltip": {
+      "version": "5.29.1",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.29.1.tgz",
+      "integrity": "sha512-rmJmEb/p99xWhwmVT7F7riLG08wwKykjHiMGbDPloNJk3tdI73oHsVOwzZ4SRjqMdd5/xwb/4nmz0RcoMfY7Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.1",
+        "classnames": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
+      }
+    },
     "node_modules/read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
@@ -13379,16 +13397,6 @@
       "license": "MIT",
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
-      }
-    },
-    "node_modules/tinyrainbow": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
-      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/tinyspy": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-dom": "^19.1.1",
     "react-hot-toast": "^2.6.0",
     "react-router": "^7.8.2",
+    "react-tooltip": "^5.29.1",
     "tailwindcss": "^4.1.8",
     "vite-plugin-top-level-await": "^1.6.0",
     "zustand": "^5.0.8"

--- a/src/components/LoadingOverlay.tsx
+++ b/src/components/LoadingOverlay.tsx
@@ -2,10 +2,11 @@ import cardanoIcon from '/cardano-icon.svg'
 
 interface LoadingOverlayProps {
   isVisible: boolean
-  message?: string
+  messageTop?: string
+  messageBottom?: string
 }
 
-const LoadingOverlay = ({ isVisible, message }: LoadingOverlayProps) => {
+const LoadingOverlay = ({ isVisible, messageTop, messageBottom }: LoadingOverlayProps) => {
   if (!isVisible) return null
 
   return (
@@ -15,8 +16,11 @@ const LoadingOverlay = ({ isVisible, message }: LoadingOverlayProps) => {
           {/* Bigger White Cardano Icon */}
           <img src={cardanoIcon} alt="Cardano" className="w-16 h-16 animate-pulse brightness-0 invert" />
         </div>
-        {message && (
-          <div className="text-lg font-medium text-white">{message}</div>
+        {messageTop && (
+          <div className="text-lg font-medium text-white">{messageTop}</div>
+        )}
+        {messageBottom && (
+          <div className="text-lg font-medium text-white">{messageBottom}</div>
         )}
       </div>
     </div>

--- a/src/components/LoadingOverlay.tsx
+++ b/src/components/LoadingOverlay.tsx
@@ -10,7 +10,7 @@ const LoadingOverlay = ({ isVisible, messageTop, messageBottom }: LoadingOverlay
   if (!isVisible) return null
 
   return (
-    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[9999]">
+    <div className="fixed inset-0 bg-black/80 flex items-center justify-center z-[9999]">
       <div className="flex flex-col items-center space-y-4">
         <div className="relative w-20 h-20 flex items-center justify-center">
           {/* Bigger White Cardano Icon */}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -8,11 +8,27 @@ import { useWalletStore } from '../stores/walletStore'
 const Navigation = () => {
   const location = useLocation()
   const isAccountPage = location.pathname === '/account'
-  const { isWalletModalOpen, toggleWalletModal, reconnectWallet } = useWalletStore()
+  const { isWalletModalOpen, toggleWalletModal, closeWalletModal, reconnectWallet } = useWalletStore()
 
   useEffect(() => {
     reconnectWallet()
   }, [reconnectWallet])
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth >= 768 && isWalletModalOpen) {
+        closeWalletModal()
+      }
+    }
+
+    window.addEventListener('resize', handleResize)
+    
+    handleResize()
+
+    return () => {
+      window.removeEventListener('resize', handleResize)
+    }
+  }, [isWalletModalOpen, closeWalletModal])
 
   return (
     <nav className="absolute top-0 left-0 right-0 z-50 bg-[#00000033]">
@@ -23,7 +39,7 @@ const Navigation = () => {
         {isAccountPage ? (
           <button
             onClick={toggleWalletModal}
-            className={`flex items-center justify-center cursor-pointer transition-all duration-200 ${
+            className={`md:hidden flex items-center justify-center cursor-pointer transition-all duration-200 ${
               isWalletModalOpen
                 ? 'w-12 h-12 rounded-full border-[1px] border-white'
                 : 'w-12 h-12'

--- a/src/components/TooltipGuide.tsx
+++ b/src/components/TooltipGuide.tsx
@@ -1,0 +1,93 @@
+import { useState, useEffect, type ReactNode } from 'react'
+import { Tooltip } from 'react-tooltip'
+
+export interface TooltipStep {
+  id: string
+  content: string
+  placement?: 'top' | 'bottom' | 'left' | 'right'
+}
+
+interface TooltipGuideProps {
+  steps: TooltipStep[]
+  storageKey: string
+  stepDuration?: number
+  onComplete?: () => void
+  children: ReactNode
+}
+
+const TooltipGuide = ({ 
+  steps, 
+  storageKey, 
+  onComplete,
+  children 
+}: TooltipGuideProps) => {
+  const [showTooltips, setShowTooltips] = useState<boolean>(false)
+  const [currentStep, setCurrentStep] = useState<number>(0)
+
+  useEffect(() => {
+    const hasVisited = localStorage.getItem(storageKey)
+    if (!hasVisited) {
+      setTimeout(() => {
+        setShowTooltips(true)
+      }, 500)
+      localStorage.setItem(storageKey, 'true')
+    }
+  }, [storageKey])
+
+
+  const handleNextStep = () => {
+    if (currentStep < steps.length - 1) {
+      setCurrentStep(prev => prev + 1)
+    } else {
+      setShowTooltips(false)
+      onComplete?.()
+    }
+  }
+
+  const renderTooltipContent = (content: string) => {
+    return (
+      <div className="flex flex-col gap-3">
+        <div className="text-base leading-relaxed">
+          {content}
+        </div>
+        <div className="flex justify-end">
+          <button
+            onClick={handleNextStep}
+            className="bg-white/20 hover:bg-white/30 text-white px-3 py-1.5 rounded-md text-sm transition-all duration-200 font-medium cursor-pointer"
+          >
+            {currentStep < steps.length - 1 ? 'Next' : 'Got it!'}
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      {children}      
+      {steps.map((step, index) => (
+        <Tooltip
+          key={step.id}
+          id={step.id}
+          place={step.placement || 'top'}
+          isOpen={showTooltips && currentStep === index}
+          clickable={true}
+          style={{
+            backgroundColor: '#9400FF',
+            color: 'white',
+            borderRadius: '12px',
+            padding: '16px',
+            fontSize: '20px',
+            maxWidth: '350px',
+            zIndex: showTooltips && currentStep === index ? 10000 : 9999, 
+            boxShadow: '0 10px 25px -5px rgba(0, 0, 0, 0.25), 0 8px 10px -6px rgba(0, 0, 0, 0.1)'
+          }}
+        >
+          {renderTooltipContent(step.content)}
+        </Tooltip>
+      ))}
+    </>
+  )
+}
+
+export default TooltipGuide 

--- a/src/components/VpnInstance.tsx
+++ b/src/components/VpnInstance.tsx
@@ -29,13 +29,7 @@ const VpnInstance = ({ region, duration, status, expires, onDelete, onAction }: 
           <p className="text-sm md:text-base">Expires: {expires}</p>
         </div>
       </div>
-      <div className="flex justify-between items-center w-full">
-        <img
-          className="w-5 h-5 cursor-pointer"
-          src={trashIcon}
-          alt="trash icon"
-          onClick={onDelete}
-        />
+      <div className="flex justify-end items-center w-full">
         <button
           className="flex items-center justify-center gap-3 rounded-md py-1.5 px-3.5 backdrop-blur-xs box-shadow-sm cursor-pointer bg-white text-black"
           onClick={onAction}

--- a/src/components/VpnInstance.tsx
+++ b/src/components/VpnInstance.tsx
@@ -1,5 +1,3 @@
-import trashIcon from '/trash-icon.svg'
-
 interface VpnInstanceProps {
   region: string
   duration: string
@@ -9,7 +7,7 @@ interface VpnInstanceProps {
   onAction?: () => void
 }
 
-const VpnInstance = ({ region, duration, status, expires, onDelete, onAction }: VpnInstanceProps) => {
+const VpnInstance = ({ region, duration, status, expires, onAction }: VpnInstanceProps) => {
   return (
     <div className={`flex p-4 flex-col justify-center items-start gap-3 w-full rounded-md backdrop-blur-xs ${
         status === "Active"

--- a/src/components/WalletModal.tsx
+++ b/src/components/WalletModal.tsx
@@ -6,7 +6,7 @@ interface WalletModalProps {
 }
 
 const WalletModal = ({ isOpen, onDisconnect }: WalletModalProps) => {
-  const { balance, enabledWallet, walletAddress, isConnected, connect } = useWalletStore()
+  const { enabledWallet, walletAddress, isConnected, connect } = useWalletStore()
   
   if (!isOpen) return null
 
@@ -32,25 +32,22 @@ const WalletModal = ({ isOpen, onDisconnect }: WalletModalProps) => {
   }
 
   return (
-    <div className="w-full bg-transparent flex justify-end">
-      <div className="min-w-full sm:min-w-[37.8125rem] px-4 py-8">
+    <div className="w-full bg-transparent flex justify-center">
+      <div className="min-w-full px-4 py-14">
         <div className="border-1 border-white rounded-md bg-transparent p-6">
           {!isConnected ? (
             // Wallet not connected - show connection prompt
             <div className="flex flex-col items-start gap-2">
               <div className="flex items-center gap-3">
                 <img
-                  src="/wallet-icon-white.svg"
-                  alt="Wallet"
-                  className="w-8 h-8"
+                  src="/cardano-icon.svg"
+                  alt="cardano-icon"
+                  className="w-10 h-10 brightness-0 invert"
                 />
                 <div className="flex flex-col">
                   <h3 className="text-white font-medium text-lg">Connect Wallet</h3>
                   <p className="text-white/70 text-sm">Connect your wallet to purchase VPN access</p>
                 </div>
-              </div>
-              <div className="text-center">
-                <p className="text-white text-lg font-bold">0.00 <span className="text-sm font-normal">ADA</span></p>
               </div>
               <button
                 onClick={handleConnect}
@@ -66,29 +63,21 @@ const WalletModal = ({ isOpen, onDisconnect }: WalletModalProps) => {
               <div className="flex flex-col gap-4">
                 <div className="flex items-center gap-3">
                   <img
-                    src="/wallet-icon-white.svg"
+                    src="/cardano-icon.svg"
                     alt="Wallet"
-                    className="w-8 h-8"
+                    className="w-10 h-10 brightness-0 invert"
                   />
                   <div className="flex flex-col">
                     <h3 className="text-white font-medium text-lg">Your Wallet</h3>
-                    <p className="text-white/70 text-sm max-w-[10rem] truncate">{enabledWallet}: {walletAddress}</p>
+                    <p className="text-white/70 text-sm max-w-[15rem] truncate">{enabledWallet}: {walletAddress}</p>
                   </div>
                 </div>
                 <button
                   onClick={onDisconnect}
-                  className="bg-white text-black px-6 py-2 rounded-lg font-medium w-fit self-start"
+                  className="bg-white text-black px-6 py-2 rounded-lg font-medium w-fit self-start cursor-pointer hover:bg-[#f5f5f5] hover:scale-102"
                 >
                   Disconnect
                 </button>
-              </div>
-
-              {/* Right side */}
-              <div className="text-right">
-                <p className="text-white/70 text-sm mb-2 font-normal">Wallet Balance</p>
-                <p className="text-white text-2xl font-bold">
-                  {balance || "0.00"} <span className="text-sm font-normal">ADA</span>
-                </p>
               </div>
             </div>
           )}

--- a/src/components/WalletModal.tsx
+++ b/src/components/WalletModal.tsx
@@ -33,7 +33,7 @@ const WalletModal = ({ isOpen, onDisconnect }: WalletModalProps) => {
 
   return (
     <div className="w-full bg-transparent flex justify-center">
-      <div className="min-w-full px-4 py-14">
+      <div className="min-w-full py-10">
         <div className="border-1 border-white rounded-md bg-transparent p-6">
           {!isConnected ? (
             // Wallet not connected - show connection prompt
@@ -46,12 +46,12 @@ const WalletModal = ({ isOpen, onDisconnect }: WalletModalProps) => {
                 />
                 <div className="flex flex-col">
                   <h3 className="text-white font-medium text-lg">Connect Wallet</h3>
-                  <p className="text-white/70 text-sm">Connect your wallet to purchase VPN access</p>
+                  <p className="text-white/70 text-md py-2">Connect your wallet to purchase VPN access</p>
                 </div>
               </div>
               <button
                 onClick={handleConnect}
-                className="bg-white text-black px-6 py-2 rounded-lg font-medium w-fit"
+                className="bg-white text-black px-6 py-2 rounded-lg font-medium w-fit cursor-pointer hover:bg-[#f5f5f5] hover:scale-102"
               >
                 Connect Wallet
               </button>
@@ -69,7 +69,7 @@ const WalletModal = ({ isOpen, onDisconnect }: WalletModalProps) => {
                   />
                   <div className="flex flex-col">
                     <h3 className="text-white font-medium text-lg">Your Wallet</h3>
-                    <p className="text-white/70 text-sm max-w-[15rem] truncate">{enabledWallet}: {walletAddress}</p>
+                    <p className="text-white/70 text-md max-w-[15rem] py-1 truncate">{enabledWallet}: {walletAddress}</p>
                   </div>
                 </div>
                 <button

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router'
 import './index.css'
 import VpnApp from './App.tsx'
+import 'react-tooltip/dist/react-tooltip.css'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -189,17 +189,29 @@ const Account = () => {
   const vpnInstances = useMemo(() => {
     if (!dedupedClientList) return []
     
-    return dedupedClientList.map((client: ClientInfo) => {
-      const isActive = new Date(client.expiration) > new Date()
-      
-      return {
-        id: client.id,
-        region: client.region,
-        duration: formatTimeRemaining(client.expiration),
-        status: isActive ? 'Active' as const : 'Expired' as const,
-        expires: new Date(client.expiration).toLocaleDateString()
-      }
-    })
+    return dedupedClientList
+      .map((client: ClientInfo) => {
+        const isActive = new Date(client.expiration) > new Date()
+        
+        return {
+          id: client.id,
+          region: client.region,
+          duration: formatTimeRemaining(client.expiration),
+          status: isActive ? 'Active' as const : 'Expired' as const,
+          expires: new Date(client.expiration).toLocaleDateString(),
+          expirationDate: new Date(client.expiration)
+        }
+      })
+      .sort((a, b) => {
+        if (a.status === 'Active' && b.status === 'Expired') return -1
+        if (a.status === 'Expired' && b.status === 'Active') return 1
+        
+        if (a.status === 'Active') {
+          return b.expirationDate.getTime() - a.expirationDate.getTime()
+        } else {
+          return b.expirationDate.getTime() - a.expirationDate.getTime()
+        }
+      })
   }, [dedupedClientList])
 
   return (

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -6,6 +6,7 @@ import WalletModal from "../components/WalletModal"
 import { showSuccess, showError } from "../utils/toast"
 import type { ClientInfo } from '../api/types'
 import LoadingOverlay from "../components/LoadingOverlay"
+import TooltipGuide, { type TooltipStep } from "../components/TooltipGuide"
 
 const Account = () => {
   const { 
@@ -19,6 +20,39 @@ const Account = () => {
   } = useWalletStore()
   const [selectedDuration, setSelectedDuration] = useState<number>(0)
   const [selectedRegion, setSelectedRegion] = useState<string>("")
+
+  const tooltipSteps: TooltipStep[] = [
+    {
+      id: "duration-tooltip",
+      content: "Choose how long you want your VPN access to last. Longer durations offer better value!",
+      placement: "top"
+    },
+    {
+      id: "price-tooltip", 
+      content: "This shows the cost in ADA for your selected duration. Make sure you have enough balance!",
+      placement: "bottom"
+    },
+    {
+      id: "region-tooltip",
+      content: "Select the server region closest to you for the best performance, or choose a different region for location privacy.",
+      placement: "top"
+    },
+    {
+      id: "wallet-tooltip",
+      content: "Connect your Cardano wallet here to start purchasing VPN access. We support all major Cardano wallets!",
+      placement: "left"
+    },
+    {
+      id: "purchase-tooltip",
+      content: "Click here to purchase your VPN access! Make sure your wallet is connected and you have enough ADA balance.",
+      placement: "top"
+    },
+    {
+      id: "instances-tooltip",
+      content: "Your active VPN instances will appear here. Click 'Get Config' to download your VPN configuration files!",
+      placement: "top"
+    }
+  ]
 
   const { data: refData } = useRefData({
     queryKey: ['refdata'],
@@ -215,165 +249,185 @@ const Account = () => {
   }, [dedupedClientList])
 
   return (
-    <div className="min-h-screen min-w-screen flex flex-col items-center justify-start bg-[linear-gradient(180deg,#1C246E_0%,#040617_12.5%)] pt-16">
-      <div className="flex flex-col items-center justify-center pt-8 gap-6 md:pt-12 md:gap-8 z-20 text-white w-full max-w-none md:max-w-[80rem] px-4 md:px-8">
-        <LoadingOverlay 
-          isVisible={signupMutation.isPending}
-          messageTop={signupMutation.isPending ? 'Awaiting Transaction Confirmation' : ''}
-          messageBottom="Processing Purchase" 
-        />
-        
-        {/* VPN PURCHASE SECTION */}
-        <div className="flex flex-col gap-6 w-full md:flex-row md:gap-8 md:items-start">
-          {/* VPN PURCHASE OPTIONS */}
-          <div className="flex flex-col justify-center items-start gap-3 w-full md:flex-1">
-            <div className="flex justify-between items-start gap-3 pb-4 w-full">
-              <div className="flex flex-col justify-center items-start gap-3">
-                <p className="font-exo-2 text-white text-lg font-bold">Buy VPN Access</p>
-              </div>
-              <div className="flex flex-col justify-center items-end gap-3">
-                <p className="font-light text-white text-sm">Available Balance</p>
-                <p className="font-light text-white text-sm">
-                  <span className="font-bold text-2xl">{balance ? balance : "0.00"}</span> ADA
-                </p>
-              </div>
-            </div>
-            
-            {/* Duration Selection */}
-            <div className="flex flex-col justify-center items-start gap-2 p-3 w-full rounded-md bg-[linear-gradient(180deg,rgba(148,0,255,0.60)_0%,rgba(104,0,178,0.60)_100%)]">
-              <div className="flex flex-col justify-center items-start gap-2 w-full">
-                {Array.isArray(refData?.prices) && refData.prices.length > 0 ? (
-                  <>
-                    <div className="flex items-center gap-2 w-full">
-                      {durationOptions.map((option: { value: number; label: string; timeDisplay: string }) => (
-                        <button
-                          key={option.value}
-                          className={`flex items-center justify-center gap-2.5 flex-1 rounded-sm bg-white text-black py-1.5 px-3 cursor-pointer whitespace-nowrap text-md md:text-md ${
-                            selectedDuration === option.value ? "opacity-100" : "opacity-50"
-                          }`}
-                          onClick={() => setSelectedDuration(option.value)}
-                        >
-                          {option.label}
-                        </button>
-                      ))}
-                    </div>
-                    <div className="text-lg flex justify-center items-center gap-2 w-full bg-[#000000A6] rounded-md py-3 px-2.5">
-                      {selectedOption ? `${formatPrice(selectedOption.price)} ADA` : ''}
-                    </div>
-                  </>
-                ) : (
-                  <div className="h-20 w-full bg-gray-300/20 rounded animate-pulse"></div>
-                )}
-              </div>
-            </div>
-            
-            {/* Region Selection and Purchase */}
-            <div className="flex flex-row gap-2 w-full justify-between items-center">
-              <div className="flex items-center gap-2">
-                <p className="font-medium text-white text-lg">Region:</p>
-                {Array.isArray(refData?.regions) && refData.regions.length > 0 ? (
-                  <select 
-                    value={selectedRegion}
-                    onChange={(e) => setSelectedRegion(e.target.value)}
-                    className="bg-transparent text-white text-md border border-white/20 rounded px-2 py-3"
-                  >
-                    {refData.regions.map((region) => (
-                      <option key={region} value={region} className="text-black">
-                        {region.toUpperCase()}
-                      </option>
-                    ))}
-                  </select>
-                ) : (
-                  <div className="h-7 w-24 bg-gray-300/20 rounded animate-pulse"></div>
-                )}
-              </div>
-              {Array.isArray(refData?.prices) && refData.prices.length > 0 ? (
-                <button 
-                  className={`flex items-center justify-center gap-2.5 rounded-md py-1 px-2.5 backdrop-blur-sm transition-all duration-200 ${
-                    signupMutation.isPending || !isConnected 
-                      ? 'opacity-50 cursor-not-allowed bg-gray-500 py-2.5 px-12' 
-                      : 'cursor-pointer bg-[#9400FF] py-2.5 px-12 hover:bg-[#7A00CC] hover:scale-102'
-                  }`}
-                  onClick={handlePurchase}
-                  disabled={signupMutation.isPending || !isConnected}
-                >
-                  <p className="font-medium text-white text-lg">
-                    {signupMutation.isPending 
-                      ? 'Processing...' 
-                      : !isConnected 
-                        ? 'Connect Wallet' 
-                        : `Purchase VPN`
-                    }
+    <TooltipGuide
+      steps={tooltipSteps}
+      storageKey="vpn-account-visited"
+      stepDuration={4000}
+    >
+      <div className="min-h-screen min-w-screen flex flex-col items-center justify-start bg-[linear-gradient(180deg,#1C246E_0%,#040617_12.5%)] pt-16">
+        <div className="flex flex-col items-center justify-center pt-8 gap-6 md:pt-12 md:gap-8 z-20 text-white w-full max-w-none md:max-w-[80rem] px-4 md:px-8">
+          <LoadingOverlay 
+            isVisible={signupMutation.isPending}
+            messageTop={signupMutation.isPending ? 'Awaiting Transaction Confirmation' : ''}
+            messageBottom="Processing Purchase" 
+          />
+          
+          {/* VPN PURCHASE SECTION */}
+          <div className="flex flex-col gap-6 w-full md:flex-row md:gap-8 md:items-start">
+            {/* VPN PURCHASE OPTIONS */}
+            <div className="flex flex-col justify-center items-start gap-3 w-full md:flex-1">
+              <div className="flex justify-between items-start gap-3 pb-4 w-full">
+                <div className="flex flex-col justify-center items-start gap-3">
+                  <p className="font-exo-2 text-white text-lg font-bold">Buy VPN Access</p>
+                </div>
+                <div className="flex flex-col justify-center items-end gap-3">
+                  <p className="font-light text-white text-sm">Available Balance</p>
+                  <p className="font-light text-white text-sm">
+                    <span className="font-bold text-2xl">{balance ? balance : "0.00"}</span> ADA
                   </p>
-                </button>
-              ) : (
-                <div className="h-8 w-32 bg-gray-300/20 rounded-md animate-pulse"></div>
-              )}
+                </div>
+              </div>
+              
+              {/* Duration Selection */}
+              <div 
+                className="flex flex-col justify-center items-start gap-2 p-3 w-full rounded-md bg-[linear-gradient(180deg,rgba(148,0,255,0.60)_0%,rgba(104,0,178,0.60)_100%)]"
+                data-tooltip-id="duration-tooltip"
+              >
+                <div className="flex flex-col justify-center items-start gap-2 w-full">
+                  {Array.isArray(refData?.prices) && refData.prices.length > 0 ? (
+                    <>
+                      <div className="flex items-center gap-2 w-full">
+                        {durationOptions.map((option: { value: number; label: string; timeDisplay: string }) => (
+                          <button
+                            key={option.value}
+                            className={`flex items-center justify-center gap-2.5 flex-1 rounded-sm bg-white text-black py-1.5 px-3 cursor-pointer whitespace-nowrap text-md md:text-md ${
+                              selectedDuration === option.value ? "opacity-100" : "opacity-50"
+                            }`}
+                            onClick={() => setSelectedDuration(option.value)}
+                          >
+                            {option.label}
+                          </button>
+                        ))}
+                      </div>
+                      <div 
+                        className="text-lg flex justify-center items-center gap-2 w-full bg-[#000000A6] rounded-md py-3 px-2.5"
+                        data-tooltip-id="price-tooltip"
+                      >
+                        {selectedOption ? `${formatPrice(selectedOption.price)} ADA` : ''}
+                      </div>
+                    </>
+                  ) : (
+                    <div className="h-20 w-full bg-gray-300/20 rounded animate-pulse"></div>
+                  )}
+                </div>
+              </div>
+              
+              {/* Region Selection and Purchase */}
+              <div className="flex flex-row gap-2 w-full justify-between items-center">
+                <div className="flex items-center gap-2">
+                  <p className="font-medium text-white text-lg">Region:</p>
+                  {Array.isArray(refData?.regions) && refData.regions.length > 0 ? (
+                    <select 
+                      value={selectedRegion}
+                      onChange={(e) => setSelectedRegion(e.target.value)}
+                      className="bg-transparent text-white text-md border border-white/20 rounded px-2 py-3"
+                      data-tooltip-id="region-tooltip"
+                    >
+                      {refData.regions.map((region) => (
+                        <option key={region} value={region} className="text-black">
+                          {region.toUpperCase()}
+                        </option>
+                      ))}
+                    </select>
+                  ) : (
+                    <div className="h-7 w-24 bg-gray-300/20 rounded animate-pulse"></div>
+                  )}
+                </div>
+                {Array.isArray(refData?.prices) && refData.prices.length > 0 ? (
+                  <button 
+                    className={`flex items-center justify-center gap-2.5 rounded-md py-1 px-2.5 backdrop-blur-sm transition-all duration-200 ${
+                      signupMutation.isPending || !isConnected 
+                        ? 'opacity-50 cursor-not-allowed bg-gray-500 py-2.5 px-12' 
+                        : 'cursor-pointer bg-[#9400FF] py-2.5 px-12 hover:bg-[#7A00CC] hover:scale-102'
+                    }`}
+                    onClick={handlePurchase}
+                    disabled={signupMutation.isPending || !isConnected}
+                    data-tooltip-id="purchase-tooltip"
+                  >
+                    <p className="font-medium text-white text-lg">
+                      {signupMutation.isPending 
+                        ? 'Processing...' 
+                        : !isConnected 
+                          ? 'Connect Wallet' 
+                          : `Purchase VPN`
+                      }
+                    </p>
+                  </button>
+                ) : (
+                  <div className="h-8 w-32 bg-gray-300/20 rounded-md animate-pulse"></div>
+                )}
+              </div>
+            </div>
+            
+            {/* WALLET SECTION */}
+            <div 
+              className={`flex flex-col items-center justify-center w-full md:flex-1 ${
+                !isConnected ? 'flex' : (!isWalletModalOpen ? 'hidden md:flex' : 'flex')
+              }`}
+              data-tooltip-id="wallet-tooltip"
+            >
+              <WalletModal
+                isOpen={true}
+                onDisconnect={handleDisconnect}
+              />
             </div>
           </div>
           
-          {/* WALLET SECTION */}
-          <div className={`flex flex-col items-center justify-center w-full md:flex-1 ${
-            !isConnected ? 'flex' : (!isWalletModalOpen ? 'hidden md:flex' : 'flex')
-          }`}>
-            <WalletModal
-              isOpen={true}
-              onDisconnect={handleDisconnect}
-            />
-          </div>
-        </div>
-        
-        {/* VPN INSTANCES SECTION */}
-        <div className="flex flex-col justify-center items-start gap-3 w-full">
-          <p className="text-white text-lg font-bold">VPN Instances</p>
-          <div className="w-full">
-            {!isConnected ? (
-              <p className="text-white/60 text-sm">Connect your wallet to view VPN instances</p>
-            ) : isLoadingClients ? (
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4 w-full">
-                {[1, 2, 3, 4].map((index) => (
-                  <div key={index} className="flex p-4 flex-col justify-center items-start gap-3 w-full rounded-md backdrop-blur-xs bg-[rgba(255,255,255,0.20)]">
-                    <div className="flex flex-col items-start gap-1 w-full">
-                      <div className="flex justify-between items-start w-full gap-2">
-                        <div className="h-4 bg-gray-300/20 rounded animate-pulse w-20"></div>
-                        <div className="h-4 bg-gray-300/20 rounded animate-pulse w-24"></div>
-                      </div>
-                      <div className="flex justify-between items-start w-full">
-                        <div className="flex items-center gap-2">
-                          <div className="h-4 bg-gray-300/20 rounded animate-pulse w-16"></div>
-                          <div className="w-2 h-2 bg-gray-300/20 rounded-full animate-pulse"></div>
+          {/* VPN INSTANCES SECTION */}
+          <div className="flex flex-col justify-center items-start gap-3 w-full">
+            <p className="text-white text-lg font-bold">VPN Instances</p>
+            <div className="w-full">
+              {!isConnected ? (
+                <p className="text-white/60 text-sm">Connect your wallet to view VPN instances</p>
+              ) : isLoadingClients ? (
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4 w-full">
+                  {[1, 2, 3, 4].map((index) => (
+                    <div key={index} className="flex p-4 flex-col justify-center items-start gap-3 w-full rounded-md backdrop-blur-xs bg-[rgba(255,255,255,0.20)]">
+                      <div className="flex flex-col items-start gap-1 w-full">
+                        <div className="flex justify-between items-start w-full gap-2">
+                          <div className="h-4 bg-gray-300/20 rounded animate-pulse w-20"></div>
+                          <div className="h-4 bg-gray-300/20 rounded animate-pulse w-24"></div>
                         </div>
-                        <div className="h-4 bg-gray-300/20 rounded animate-pulse w-20"></div>
+                        <div className="flex justify-between items-start w-full">
+                          <div className="flex items-center gap-2">
+                            <div className="h-4 bg-gray-300/20 rounded animate-pulse w-16"></div>
+                            <div className="w-2 h-2 bg-gray-300/20 rounded-full animate-pulse"></div>
+                          </div>
+                          <div className="h-4 bg-gray-300/20 rounded animate-pulse w-20"></div>
+                        </div>
+                      </div>
+                      <div className="flex justify-between items-center w-full">
+                        <div className="w-5 h-5 bg-gray-300/20 rounded animate-pulse"></div>
+                        <div className="h-8 bg-gray-300/20 rounded-md animate-pulse w-24"></div>
                       </div>
                     </div>
-                    <div className="flex justify-between items-center w-full">
-                      <div className="w-5 h-5 bg-gray-300/20 rounded animate-pulse"></div>
-                      <div className="h-8 bg-gray-300/20 rounded-md animate-pulse w-24"></div>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            ) : vpnInstances.length > 0 ? (
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4 w-full">
-                {vpnInstances.map((instance) => (
-                  <VpnInstance
-                    key={instance.id}
-                    region={instance.region}
-                    duration={instance.duration}
-                    status={instance.status}
-                    expires={instance.expires}
-                    onDelete={() => handleDelete(instance.id)}
-                    onAction={() => handleAction(instance.id, instance.status === 'Active' ? 'Get Config' : 'Renew Access')}
-                  />
-                ))}
-              </div>
-            ) : (
-              <p className="text-white/60 text-sm">No VPN instances found</p>
-            )}
+                  ))}
+                </div>
+              ) : vpnInstances.length > 0 ? (
+                <div 
+                  className="grid grid-cols-1 md:grid-cols-2 gap-4 w-full"
+                  data-tooltip-id="instances-tooltip"
+                >
+                  {vpnInstances.map((instance) => (
+                    <VpnInstance
+                      key={instance.id}
+                      region={instance.region}
+                      duration={instance.duration}
+                      status={instance.status}
+                      expires={instance.expires}
+                      onDelete={() => handleDelete(instance.id)}
+                      onAction={() => handleAction(instance.id, instance.status === 'Active' ? 'Get Config' : 'Renew Access')}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <p className="text-white/60 text-sm">No VPN instances found</p>
+              )}
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </TooltipGuide>
   )
 }
 

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -117,7 +117,6 @@ const Account = () => {
   }, [refData?.regions, selectedRegion])
 
   const selectedOption = durationOptions.find((option: { value: number }) => option.value === selectedDuration)
-  const currentPrice = selectedOption ? formatPrice(selectedOption.price) : "0.00"
 
   const handlePurchase = () => {
     if (!walletAddress) {
@@ -213,8 +212,9 @@ const Account = () => {
     <div className="min-h-screen min-w-screen flex flex-col items-center justify-start bg-[linear-gradient(180deg,#1C246E_0%,#040617_12.5%)] pt-16">
       <div className="flex flex-col items-center justify-center pt-8 gap-6 md:pt-12 md:gap-8 z-20 text-white w-full max-w-none md:max-w-[80rem] px-4 md:px-8">
         <LoadingOverlay 
-          isVisible={signupMutation.isPending} 
-          message="Processing Purchase..." 
+          isVisible={signupMutation.isPending}
+          messageTop={signupMutation.isPending ? 'Awaiting Transaction Confirmation' : ''}
+          messageBottom="Processing Purchase" 
         />
         
         {/* VPN PURCHASE SECTION */}
@@ -242,7 +242,7 @@ const Account = () => {
                       {durationOptions.map((option: { value: number; label: string; timeDisplay: string }) => (
                         <button
                           key={option.value}
-                          className={`flex items-center justify-center gap-2.5 flex-1 rounded-sm bg-white text-black py-1 px-2.5 cursor-pointer whitespace-nowrap text-xs md:text-sm ${
+                          className={`flex items-center justify-center gap-2.5 flex-1 rounded-sm bg-white text-black py-1.5 px-3 cursor-pointer whitespace-nowrap text-md md:text-md ${
                             selectedDuration === option.value ? "opacity-100" : "opacity-50"
                           }`}
                           onClick={() => setSelectedDuration(option.value)}
@@ -251,8 +251,8 @@ const Account = () => {
                         </button>
                       ))}
                     </div>
-                    <div className="flex justify-center items-center gap-2 w-full bg-[#000000A6] rounded-md py-2 px-2.5">
-                      {selectedOption?.timeDisplay}
+                    <div className="text-lg flex justify-center items-center gap-2 w-full bg-[#000000A6] rounded-md py-3 px-2.5">
+                      {selectedOption ? `${formatPrice(selectedOption.price)} ADA` : ''}
                     </div>
                   </>
                 ) : (
@@ -269,7 +269,7 @@ const Account = () => {
                   <select 
                     value={selectedRegion}
                     onChange={(e) => setSelectedRegion(e.target.value)}
-                    className="bg-transparent text-white text-sm border border-white/20 rounded px-2 py-1"
+                    className="bg-transparent text-white text-md border border-white/20 rounded px-2 py-3"
                   >
                     {refData.regions.map((region) => (
                       <option key={region} value={region} className="text-black">
@@ -283,20 +283,20 @@ const Account = () => {
               </div>
               {Array.isArray(refData?.prices) && refData.prices.length > 0 ? (
                 <button 
-                  className={`flex items-center justify-center gap-2.5 rounded-md py-1 px-2.5 backdrop-blur-sm ${
+                  className={`flex items-center justify-center gap-2.5 rounded-md py-1 px-2.5 backdrop-blur-sm transition-all duration-200 ${
                     signupMutation.isPending || !isConnected 
-                      ? 'opacity-50 cursor-not-allowed bg-gray-500' 
-                      : 'cursor-pointer bg-[#9400FF]'
+                      ? 'opacity-50 cursor-not-allowed bg-gray-500 py-2 px-12' 
+                      : 'cursor-pointer bg-[#9400FF] py-2 px-12 hover:bg-[#7A00CC] hover:scale-102'
                   }`}
                   onClick={handlePurchase}
                   disabled={signupMutation.isPending || !isConnected}
                 >
-                  <p className="font-light text-white text-sm">
+                  <p className="font-medium text-white text-lg">
                     {signupMutation.isPending 
                       ? 'Processing...' 
                       : !isConnected 
                         ? 'Connect Wallet' 
-                        : `Purchase ${currentPrice} ADA`
+                        : `Purchase VPN`
                     }
                   </p>
                 </button>


### PR DESCRIPTION
## UI changes, layouts, tooltips
- added first time visitor tooltips through local storage
- changed vpn instances to be two layouts instead of one
- removed ada pricing in the wallet modal and added cardano icon
- mobile screen version has cardano icon in navigation to close and open up the wallet modal, opens on default when screen is not mobile size
- added tooltip component
- changed button size for puchasing
- added more loading text to be more apparent about waiting for transaction to be compelete
- sorted vpn instances by active and then most recently expired

<img width="1299" height="792" alt="Screenshot 2025-09-09 at 11 50 14 PM" src="https://github.com/user-attachments/assets/188d95c3-d9df-42b9-8dd4-5bcb0af3442c" />
<img width="1299" height="792" alt="Screenshot 2025-09-09 at 11 50 30 PM" src="https://github.com/user-attachments/assets/5c562c07-8624-47ba-8c98-a4f0c080c742" />
<img width="500" height="792" alt="Screenshot 2025-09-09 at 11 51 18 PM" src="https://github.com/user-attachments/assets/58c21a62-d2a6-4f9a-9fbc-6f4fa0e88c51" />
<img width="500" height="792" alt="Screenshot 2025-09-09 at 11 51 45 PM" src="https://github.com/user-attachments/assets/a7c8d7d3-9a84-4df6-a2b9-a69b166ab8b0" />
<img width="500" height="792" alt="Screenshot 2025-09-09 at 11 51 53 PM" src="https://github.com/user-attachments/assets/ca1d1f1e-61c7-41f8-a9af-ef541599f3f5" />
<img width="959" height="792" alt="Screenshot 2025-09-09 at 11 52 22 PM" src="https://github.com/user-attachments/assets/37524230-8a16-4940-be91-52327786e4fa" />
<img width="959" height="792" alt="Screenshot 2025-09-09 at 11 52 30 PM" src="https://github.com/user-attachments/assets/b4c2e911-b8a3-4e38-b55f-73d99745b135" />
<img width="959" height="792" alt="Screenshot 2025-09-09 at 11 52 41 PM" src="https://github.com/user-attachments/assets/8be313ca-f8a5-4983-b585-8949d7c7d035" />
