### PR TITLE
fix: remove spinner on add new button

### DIFF
--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -815,9 +815,7 @@ const Account = () => {
                 )}
                 {!isInstancesLoading && isConnected && vpnInstances.length > 0 && (
                   <button
-                    className={`flex-shrink-0 rounded-full py-2 px-5 text-black font-semibold text-sm bg-white transition-all cursor-pointer hover:scale-[1.01] ${
-                      areAllInstancesExpired ? "spinning-gradient-border" : ""
-                    }`}
+                    className="flex-shrink-0 rounded-full py-2 px-5 text-black font-semibold text-sm bg-white transition-all cursor-pointer hover:scale-[1.01]"
                     onClick={() => setShowAdditionalPurchaseCards(true)}
                   >
                     + Add New


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the spinner effect from the “+ Add New” button on the Account page to prevent distracting motion. The button now keeps a consistent style regardless of instance status.

<sup>Written for commit c85230c55f26506098d0296d866339c6e92de0a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed spinning gradient border animation from the "+ Add New" button that appeared when all VPN instances were expired.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->