### PR TITLE
feat: wireguard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,69 @@
+# Backend API URL
+# Defaults to https://preprod-api.b7s.services if not specified
+VITE_API_URL=https://preprod-api.b7s.services
+
+# Cardano network selection: mainnet, preprod, or preview
+# Defaults to preprod if not specified
+VITE_CARDANO_NETWORK=preprod
+
+# =============================================================================
+# Protocol Configuration
+# =============================================================================
+#
+# These two variables control which VPN protocols are available in the UI.
+# The frontend dynamically adjusts content based on the combination of values.
+
+# WireGuard feature flag
+# Set to 'true' to enable WireGuard protocol UI
+# Default: false (if unset or any value other than 'true')
+VITE_WIREGUARD_ENABLED=false
+
+# OpenVPN region identifier(s)
+# Comma-separated list of OpenVPN region IDs from refdata
+# Default: unset (OpenVPN flows hidden entirely)
+# Note: preprod uses spaces in region names, so quote the value
+# Regions NOT in this list are treated as WireGuard regions
+VITE_OPENVPN_REGION="us east-1"
+
+# =============================================================================
+# Protocol Configuration Matrix
+# =============================================================================
+#
+# | WIREGUARD_ENABLED | OPENVPN_REGION | Result                              |
+# |-------------------|----------------|-------------------------------------|
+# | true              | set            | Both protocols, WireGuard primary   |
+# | true              | unset          | WireGuard only, no OpenVPN option   |
+# | false/unset       | set            | OpenVPN only, no WireGuard UI       |
+# | false/unset       | unset          | Legacy mode (all regions, no toggle)|
+#
+# Legacy mode (both unset): Backwards compatible with pre-WireGuard behavior.
+# All regions from refdata are shown without protocol filtering or toggle UI.
+# This is the default if no protocol variables are configured.
+
+# =============================================================================
+# Testing Different Protocol Configurations
+# =============================================================================
+#
+# Use these commands to test each mode locally against preprod:
+#
+# 1. WireGuard + OpenVPN (both protocols available):
+#    VITE_WIREGUARD_ENABLED=true VITE_OPENVPN_REGION="us east-1" npm run dev
+#
+# 2. WireGuard only (no OpenVPN option):
+#    VITE_WIREGUARD_ENABLED=true npm run dev
+#
+# 3. OpenVPN only (WireGuard disabled):
+#    VITE_WIREGUARD_ENABLED=false VITE_OPENVPN_REGION="us east-1" npm run dev
+#
+# 4. Legacy mode (no protocol UI, backwards compatible):
+#    npm run dev
+#
+# IMPORTANT: After changing environment variables, you must restart the dev
+# server. Vite bakes these values in at build time, so changes won't take
+# effect until the server restarts.
+#
+# Pages affected by protocol configuration:
+#   - /account: Purchase flow and protocol toggle
+#   - /how-it-works: Protocol-specific architecture details
+#   - /install-guide: Installation instructions for active protocol
+#   - /docs-faqs: Protocol-aware FAQ filtering

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -86,6 +86,54 @@ export function post<T>(
   });
 }
 
+export async function postPlainText(
+  endpoint: string,
+  data?: unknown,
+  options?: RequestInit,
+): Promise<string> {
+  const url = `${API_BASE_URL}${endpoint}`;
+
+  try {
+    const { headers, ...restOptions } = options || {};
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        accept: "text/plain",
+        ...headers,
+      },
+      body: data ? JSON.stringify(data) : undefined,
+      ...restOptions,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        `API Error: ${response.status} ${response.statusText}${errorText ? ` - ${errorText}` : ""}`,
+      );
+    }
+
+    return response.text();
+  } catch (error) {
+    if (error instanceof TypeError) {
+      throw new Error("Network error: Unable to connect to the API");
+    }
+    throw error;
+  }
+}
+
+export function del<T>(
+  endpoint: string,
+  data?: unknown,
+  options?: RequestInit,
+): Promise<T> {
+  return apiClient<T>(endpoint, {
+    method: "DELETE",
+    body: data ? JSON.stringify(data) : undefined,
+    ...options,
+  });
+}
+
 // Types moved to types.ts to avoid conflicts
 
 export function getClientList(

--- a/src/api/hooks/__tests__/useWireGuard.test.tsx
+++ b/src/api/hooks/__tests__/useWireGuard.test.tsx
@@ -1,0 +1,502 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  useWireGuardRegister,
+  useWireGuardProfile,
+  useWireGuardDeletePeer,
+  useWireGuardDevices,
+} from "../useWireGuard";
+import { createTestQueryClient } from "../../../test/utils";
+import * as client from "../../client";
+import type {
+  WireGuardRegisterRequest,
+  WireGuardRegisterResponse,
+  WireGuardProfileRequest,
+  WireGuardPeerRequest,
+  WireGuardDeleteResponse,
+  WireGuardDevicesRequest,
+  WireGuardDevicesResponse,
+} from "../../types";
+
+vi.mock("../../client", () => ({
+  post: vi.fn(),
+  postPlainText: vi.fn(),
+  del: vi.fn(),
+}));
+
+const mockedPost = vi.mocked(client.post);
+const mockedPostPlainText = vi.mocked(client.postPlainText);
+const mockedDel = vi.mocked(client.del);
+
+describe("useWireGuard hooks", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = createTestQueryClient();
+    vi.resetAllMocks();
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  describe("useWireGuardRegister", () => {
+    const mockRequest: WireGuardRegisterRequest = {
+      client_id: "test-client-123",
+      timestamp: Date.now(),
+      signature: "hex-signature",
+      key: "hex-key",
+      wg_pubkey: "base64-public-key",
+    };
+
+    const mockResponse: WireGuardRegisterResponse = {
+      success: true,
+      assigned_ip: "10.8.0.2",
+      device_count: 1,
+      device_limit: 3,
+    };
+
+    it("should call correct endpoint with POST method", async () => {
+      mockedPost.mockResolvedValueOnce(mockResponse);
+
+      const { result } = renderHook(() => useWireGuardRegister(), { wrapper });
+
+      result.current.mutate(mockRequest);
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(mockedPost).toHaveBeenCalledWith(
+        "/client/wg-register",
+        mockRequest,
+      );
+    });
+
+    it("should return registration response on success", async () => {
+      mockedPost.mockResolvedValueOnce(mockResponse);
+
+      const { result } = renderHook(() => useWireGuardRegister(), { wrapper });
+
+      result.current.mutate(mockRequest);
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data).toEqual(mockResponse);
+      expect(result.current.data?.assigned_ip).toBe("10.8.0.2");
+      expect(result.current.data?.device_count).toBe(1);
+      expect(result.current.data?.device_limit).toBe(3);
+    });
+
+    it("should handle API errors", async () => {
+      const errorMessage = "Device limit exceeded";
+      mockedPost.mockRejectedValueOnce(new Error(errorMessage));
+
+      const { result } = renderHook(() => useWireGuardRegister(), { wrapper });
+
+      result.current.mutate(mockRequest);
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error?.message).toBe(errorMessage);
+    });
+
+    it("should accept custom mutation options", async () => {
+      mockedPost.mockResolvedValueOnce(mockResponse);
+      const onSuccessMock = vi.fn();
+
+      const { result } = renderHook(
+        () => useWireGuardRegister({ onSuccess: onSuccessMock }),
+        { wrapper },
+      );
+
+      result.current.mutate(mockRequest);
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(onSuccessMock).toHaveBeenCalled();
+      expect(onSuccessMock.mock.calls[0][0]).toEqual(mockResponse);
+      expect(onSuccessMock.mock.calls[0][1]).toEqual(mockRequest);
+    });
+  });
+
+  describe("useWireGuardProfile", () => {
+    const mockRequest: WireGuardProfileRequest = {
+      client_id: "test-client-123",
+      timestamp: Date.now(),
+      signature: "hex-signature",
+      key: "hex-key",
+      wg_pubkey: "base64-public-key",
+    };
+
+    const mockConfigContent = `[Interface]
+PrivateKey = base64-private-key
+Address = 10.8.0.2/24
+DNS = 1.1.1.1
+
+[Peer]
+PublicKey = server-public-key
+AllowedIPs = 0.0.0.0/0
+Endpoint = vpn.example.com:51820`;
+
+    it("should call correct endpoint with POST method", async () => {
+      mockedPostPlainText.mockResolvedValueOnce(mockConfigContent);
+
+      const { result } = renderHook(() => useWireGuardProfile(), { wrapper });
+
+      result.current.mutate(mockRequest);
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(mockedPostPlainText).toHaveBeenCalledWith(
+        "/client/wg-profile",
+        mockRequest,
+      );
+    });
+
+    it("should return plain text config content", async () => {
+      mockedPostPlainText.mockResolvedValueOnce(mockConfigContent);
+
+      const { result } = renderHook(() => useWireGuardProfile(), { wrapper });
+
+      result.current.mutate(mockRequest);
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data).toBe(mockConfigContent);
+      expect(result.current.data).toContain("[Interface]");
+      expect(result.current.data).toContain("[Peer]");
+    });
+
+    it("should handle API errors", async () => {
+      const errorMessage = "Authentication failed";
+      mockedPostPlainText.mockRejectedValueOnce(new Error(errorMessage));
+
+      const { result } = renderHook(() => useWireGuardProfile(), { wrapper });
+
+      result.current.mutate(mockRequest);
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error?.message).toBe(errorMessage);
+    });
+
+    it("should accept custom mutation options", async () => {
+      mockedPostPlainText.mockResolvedValueOnce(mockConfigContent);
+      const onSuccessMock = vi.fn();
+
+      const { result } = renderHook(
+        () => useWireGuardProfile({ onSuccess: onSuccessMock }),
+        { wrapper },
+      );
+
+      result.current.mutate(mockRequest);
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(onSuccessMock).toHaveBeenCalled();
+    });
+  });
+
+  describe("useWireGuardDeletePeer", () => {
+    const mockRequest: WireGuardPeerRequest = {
+      client_id: "test-client-123",
+      timestamp: Date.now(),
+      signature: "hex-signature",
+      key: "hex-key",
+      wg_pubkey: "base64-public-key-to-delete",
+    };
+
+    const mockResponse: WireGuardDeleteResponse = {
+      success: true,
+      remaining_devices: 2,
+    };
+
+    it("should call correct endpoint with DELETE method", async () => {
+      mockedDel.mockResolvedValueOnce(mockResponse);
+
+      const { result } = renderHook(() => useWireGuardDeletePeer(), { wrapper });
+
+      result.current.mutate(mockRequest);
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(mockedDel).toHaveBeenCalledWith("/client/wg-peer", mockRequest);
+    });
+
+    it("should return delete response on success", async () => {
+      mockedDel.mockResolvedValueOnce(mockResponse);
+
+      const { result } = renderHook(() => useWireGuardDeletePeer(), { wrapper });
+
+      result.current.mutate(mockRequest);
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data).toEqual(mockResponse);
+      expect(result.current.data?.success).toBe(true);
+      expect(result.current.data?.remaining_devices).toBe(2);
+    });
+
+    it("should handle API errors", async () => {
+      const errorMessage = "Device not found";
+      mockedDel.mockRejectedValueOnce(new Error(errorMessage));
+
+      const { result } = renderHook(() => useWireGuardDeletePeer(), { wrapper });
+
+      result.current.mutate(mockRequest);
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error?.message).toBe(errorMessage);
+    });
+
+    it("should accept custom mutation options", async () => {
+      mockedDel.mockResolvedValueOnce(mockResponse);
+      const onSuccessMock = vi.fn();
+
+      const { result } = renderHook(
+        () => useWireGuardDeletePeer({ onSuccess: onSuccessMock }),
+        { wrapper },
+      );
+
+      result.current.mutate(mockRequest);
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(onSuccessMock).toHaveBeenCalled();
+    });
+  });
+
+  describe("useWireGuardDevices", () => {
+    const mockRequest: WireGuardDevicesRequest = {
+      client_id: "test-client-123",
+      timestamp: Date.now(),
+      signature: "hex-signature",
+      key: "hex-key",
+    };
+
+    const mockResponse: WireGuardDevicesResponse = {
+      devices: [
+        {
+          pubkey: "pubkey-1",
+          assigned_ip: "10.8.0.2",
+          created_at: 1705320000,
+        },
+        {
+          pubkey: "pubkey-2",
+          assigned_ip: "10.8.0.3",
+          created_at: 1705406400,
+        },
+      ],
+      limit: 3,
+    };
+
+    it("should call correct endpoint with POST method", async () => {
+      mockedPost.mockResolvedValueOnce(mockResponse);
+
+      const { result } = renderHook(
+        () => useWireGuardDevices(mockRequest),
+        { wrapper },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(mockedPost).toHaveBeenCalledWith(
+        "/client/wg-devices",
+        mockRequest,
+      );
+    });
+
+    it("should return devices list on success", async () => {
+      mockedPost.mockResolvedValueOnce(mockResponse);
+
+      const { result } = renderHook(
+        () => useWireGuardDevices(mockRequest),
+        { wrapper },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data).toEqual(mockResponse);
+      expect(result.current.data?.devices).toHaveLength(2);
+      expect(result.current.data?.limit).toBe(3);
+    });
+
+    it("should return correct device data structure", async () => {
+      mockedPost.mockResolvedValueOnce(mockResponse);
+
+      const { result } = renderHook(
+        () => useWireGuardDevices(mockRequest),
+        { wrapper },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      const firstDevice = result.current.data?.devices[0];
+      expect(firstDevice?.pubkey).toBe("pubkey-1");
+      expect(firstDevice?.assigned_ip).toBe("10.8.0.2");
+      expect(firstDevice?.created_at).toBe(1705320000);
+    });
+
+    it("should handle empty devices list", async () => {
+      const emptyResponse: WireGuardDevicesResponse = {
+        devices: [],
+        limit: 3,
+      };
+      mockedPost.mockResolvedValueOnce(emptyResponse);
+
+      const { result } = renderHook(
+        () => useWireGuardDevices(mockRequest),
+        { wrapper },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data?.devices).toHaveLength(0);
+    });
+
+    it("should handle API errors", async () => {
+      const errorMessage = "Unauthorized";
+      mockedPost.mockRejectedValueOnce(new Error(errorMessage));
+
+      const { result } = renderHook(
+        () => useWireGuardDevices(mockRequest, { retry: false }),
+        { wrapper },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error?.message).toBe(errorMessage);
+    });
+
+    it("should accept custom query options", async () => {
+      mockedPost.mockResolvedValueOnce(mockResponse);
+
+      const { result } = renderHook(
+        () => useWireGuardDevices(mockRequest, { staleTime: 5000 }),
+        { wrapper },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data).toEqual(mockResponse);
+    });
+  });
+
+  describe("mutation state management", () => {
+    it("should track loading state during request", async () => {
+      let resolvePromise: (value: WireGuardRegisterResponse) => void;
+      const pendingPromise = new Promise<WireGuardRegisterResponse>(
+        (resolve) => {
+          resolvePromise = resolve;
+        },
+      );
+      mockedPost.mockReturnValueOnce(pendingPromise);
+
+      const { result } = renderHook(() => useWireGuardRegister(), { wrapper });
+
+      expect(result.current.isPending).toBe(false);
+
+      result.current.mutate({
+        client_id: "test",
+        timestamp: Date.now(),
+        signature: "sig",
+        key: "key",
+        wg_pubkey: "pubkey",
+      });
+
+      await waitFor(() => {
+        expect(result.current.isPending).toBe(true);
+      });
+
+      // Resolve the promise
+      resolvePromise!({
+        success: true,
+        assigned_ip: "10.8.0.2",
+        device_count: 1,
+        device_limit: 3,
+      });
+
+      await waitFor(() => {
+        expect(result.current.isPending).toBe(false);
+        expect(result.current.isSuccess).toBe(true);
+      });
+    });
+
+    it("should reset state between mutations", async () => {
+      mockedPost
+        .mockRejectedValueOnce(new Error("First error"))
+        .mockResolvedValueOnce({
+          success: true,
+          assigned_ip: "10.8.0.2",
+          device_count: 1,
+          device_limit: 3,
+        });
+
+      const { result } = renderHook(() => useWireGuardRegister(), { wrapper });
+
+      const mockRequest: WireGuardRegisterRequest = {
+        client_id: "test",
+        timestamp: Date.now(),
+        signature: "sig",
+        key: "key",
+        wg_pubkey: "pubkey",
+      };
+
+      // First mutation - error
+      result.current.mutate(mockRequest);
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      // Reset and try again
+      result.current.reset();
+      await waitFor(() => {
+        expect(result.current.isError).toBe(false);
+        expect(result.current.error).toBeNull();
+      });
+
+      // Second mutation - success
+      result.current.mutate(mockRequest);
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+    });
+  });
+});

--- a/src/api/hooks/index.ts
+++ b/src/api/hooks/index.ts
@@ -6,3 +6,9 @@ export { useClientProfile } from "./useClientProfile";
 export { useMultipleClientAvailable } from "./useMultipleClientAvailable";
 export { useClientPolling } from "./useClientPolling";
 export { useRenewVpn } from "./useRenewVpn";
+export {
+  useWireGuardRegister,
+  useWireGuardProfile,
+  useWireGuardDeletePeer,
+  useWireGuardDevices,
+} from "./useWireGuard";

--- a/src/api/hooks/useWireGuard.ts
+++ b/src/api/hooks/useWireGuard.ts
@@ -1,0 +1,72 @@
+import {
+  useMutation,
+  useQuery,
+  type UseMutationOptions,
+  type UseQueryOptions,
+} from "@tanstack/react-query";
+import { post, postPlainText, del } from "../client";
+import type {
+  WireGuardRegisterRequest,
+  WireGuardRegisterResponse,
+  WireGuardProfileRequest,
+  WireGuardPeerRequest,
+  WireGuardDeleteResponse,
+  WireGuardDevicesRequest,
+  WireGuardDevicesResponse,
+} from "../types";
+
+// Register a new device
+export function useWireGuardRegister(
+  options?: UseMutationOptions<
+    WireGuardRegisterResponse,
+    Error,
+    WireGuardRegisterRequest
+  >,
+) {
+  return useMutation({
+    mutationFn: (data: WireGuardRegisterRequest) =>
+      post<WireGuardRegisterResponse>("/client/wg-register", data),
+    ...options,
+  });
+}
+
+// Get WireGuard config (auto-registers if not found)
+export function useWireGuardProfile(
+  options?: UseMutationOptions<string, Error, WireGuardProfileRequest>,
+) {
+  return useMutation({
+    mutationFn: (data: WireGuardProfileRequest) =>
+      postPlainText("/client/wg-profile", data), // Returns text/plain
+    ...options,
+  });
+}
+
+// Delete a device
+export function useWireGuardDeletePeer(
+  options?: UseMutationOptions<
+    WireGuardDeleteResponse,
+    Error,
+    WireGuardPeerRequest
+  >,
+) {
+  return useMutation({
+    mutationFn: (data: WireGuardPeerRequest) =>
+      del<WireGuardDeleteResponse>("/client/wg-peer", data),
+    ...options,
+  });
+}
+
+// List all devices for a client
+export function useWireGuardDevices(
+  request: WireGuardDevicesRequest,
+  options?: Omit<
+    UseQueryOptions<WireGuardDevicesResponse, Error>,
+    "queryKey" | "queryFn"
+  >,
+) {
+  return useQuery({
+    queryKey: ["wireGuardDevices", request.client_id],
+    queryFn: () => post<WireGuardDevicesResponse>("/client/wg-devices", request),
+    ...options,
+  });
+}

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -78,3 +78,115 @@ export interface TxRenewRequest {
 export interface TxRenewResponse {
   txCbor: string;
 }
+
+// ============================================================================
+// WireGuard Types
+// ============================================================================
+
+/**
+ * Authentication payload required for all WireGuard API requests.
+ * Uses COSE signature verification with Ed25519 keys.
+ */
+export interface WireGuardAuthPayload {
+  /** Hex-encoded NFT asset name (subscription identifier) */
+  client_id: string;
+  /** Unix timestamp (must be within 15 minutes of server time) */
+  timestamp: number;
+  /** Hex-encoded COSE Sign1 message (payload = client_id + timestamp) */
+  signature: string;
+  /** Hex-encoded COSE Key (Ed25519 public key) */
+  key: string;
+}
+
+/**
+ * POST /api/client/wg-register - Register a new WireGuard device
+ */
+export interface WireGuardRegisterRequest extends WireGuardAuthPayload {
+  /** Base64-encoded WireGuard public key */
+  wg_pubkey: string;
+}
+
+export interface WireGuardRegisterResponse {
+  success: boolean;
+  /** Assigned IP address, e.g., "10.8.0.2" */
+  assigned_ip: string;
+  /** Current number of registered devices */
+  device_count: number;
+  /** Maximum allowed devices (default: 3) */
+  device_limit: number;
+}
+
+/**
+ * POST /api/client/wg-profile - Get WireGuard config file content
+ * Note: Auto-registers device if not already registered
+ */
+export interface WireGuardProfileRequest extends WireGuardAuthPayload {
+  /** Base64-encoded WireGuard public key */
+  wg_pubkey: string;
+}
+// Response: plain text (Content-Type: text/plain) - the .conf file content
+
+/**
+ * DELETE /api/client/wg-peer - Remove a WireGuard device
+ */
+export interface WireGuardPeerRequest extends WireGuardAuthPayload {
+  /** Base64-encoded WireGuard public key */
+  wg_pubkey: string;
+}
+
+export interface WireGuardDeleteResponse {
+  success: boolean;
+  /** Number of devices remaining after deletion */
+  remaining_devices: number;
+}
+
+/**
+ * POST /api/client/wg-devices - List all registered devices for a client
+ */
+export type WireGuardDevicesRequest = WireGuardAuthPayload;
+
+export interface WireGuardDevicesResponse {
+  devices: Array<{
+    /** Base64-encoded WireGuard public key */
+    pubkey: string;
+    /** Assigned IP address */
+    assigned_ip: string;
+    /** Unix timestamp of device registration */
+    created_at: number;
+  }>;
+  /** Maximum allowed devices */
+  limit: number;
+}
+
+/**
+ * Frontend-only device representation.
+ * Combines backend device data with locally-stored device names.
+ */
+export interface WireGuardDevice {
+  /** Base64-encoded WireGuard public key (from backend) */
+  pubkey: string;
+  /** User-assigned device name (from localStorage) */
+  name: string;
+  /** Assigned IP address (from backend) */
+  assignedIp: string;
+  /** ISO timestamp of device registration (converted from unix timestamp) */
+  createdAt: string;
+}
+
+// ============================================================================
+// VPN Instance Types
+// ============================================================================
+
+/** VPN protocol type */
+export type VpnProtocol = 'openvpn' | 'wireguard';
+
+/**
+ * Represents a VPN subscription instance.
+ * Extends ClientInfo with protocol and device information.
+ */
+export interface VpnInstance extends ClientInfo {
+  /** Protocol used by this instance */
+  protocol: VpnProtocol;
+  /** Registered devices (only for WireGuard instances, frontend-enriched) */
+  devices?: WireGuardDevice[];
+}

--- a/src/components/DeviceConfigModal.tsx
+++ b/src/components/DeviceConfigModal.tsx
@@ -1,0 +1,591 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { QRCodeSVG } from 'qrcode.react';
+import { detectDeviceType } from '../utils/deviceDetection';
+import { generateWireGuardKeypair } from '../utils/wireguardKeys';
+import { setDeviceName } from '../utils/deviceNames';
+import { useWireGuardProfile } from '../api/hooks/useWireGuard';
+import { useWalletStore } from '../stores/walletStore';
+import type { WireGuardDevice } from '../api/types';
+
+interface SignDataResponse {
+  key: string;
+  signature: string;
+}
+
+interface DeviceConfigModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  clientId: string;
+  regionName: string;
+  regionId: string;
+  existingDevice?: WireGuardDevice;
+  onDeviceCreated?: (device: WireGuardDevice) => void;
+}
+
+type ModalStep = 'naming' | 'config';
+type ConfigTab = 'qr' | 'download' | 'copy';
+
+const MAX_DEVICE_NAME_LENGTH = 32;
+const PRIVATE_KEY_PLACEHOLDER = '<REPLACE_WITH_YOUR_PRIVATE_KEY>';
+
+/**
+ * Modal for adding new WireGuard devices or re-downloading existing configs.
+ *
+ * Two flows:
+ * 1. New device: Device naming -> Generate keypair -> Get config -> Display
+ * 2. Existing device: Generate new keypair -> Get config -> Display
+ */
+export function DeviceConfigModal({
+  isOpen,
+  onClose,
+  clientId,
+  regionName,
+  regionId,
+  existingDevice,
+  onDeviceCreated,
+}: DeviceConfigModalProps) {
+  // UI state
+  const [step, setStep] = useState<ModalStep>(existingDevice ? 'config' : 'naming');
+  const [selectedTab, setSelectedTab] = useState<ConfigTab>('qr');
+
+  // Device naming state
+  const [deviceName, setDeviceNameInput] = useState('');
+  const [nameError, setNameError] = useState<string | null>(null);
+
+  // Config generation state
+  const [config, setConfig] = useState<string | null>(null);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [generationError, setGenerationError] = useState<string | null>(null);
+
+  // Copy state
+  const [copied, setCopied] = useState(false);
+  const [copyError, setCopyError] = useState(false);
+
+  // Refs
+  const modalRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const copiedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const copyErrorTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Hooks
+  const { signMessage } = useWalletStore();
+  const wireGuardProfile = useWireGuardProfile();
+
+  const headingId = 'device-config-heading';
+
+  // Initialize default device name on mount
+  useEffect(() => {
+    if (isOpen && !existingDevice) {
+      const defaultName = detectDeviceType();
+      setDeviceNameInput(defaultName);
+    }
+  }, [isOpen, existingDevice]);
+
+  // Focus management
+  useEffect(() => {
+    if (!isOpen) return;
+
+    if (step === 'naming' && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    } else if (modalRef.current) {
+      modalRef.current.focus();
+    }
+  }, [isOpen, step]);
+
+  // Handle Escape key
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
+
+  // Focus trap
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const modal = modalRef.current;
+    if (!modal) return;
+
+    const handleFocusTrap = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return;
+
+      const focusableElements = modal.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+
+      if (e.shiftKey && document.activeElement === firstElement) {
+        e.preventDefault();
+        lastElement?.focus();
+      } else if (!e.shiftKey && document.activeElement === lastElement) {
+        e.preventDefault();
+        firstElement?.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleFocusTrap);
+    return () => document.removeEventListener('keydown', handleFocusTrap);
+  }, [isOpen]);
+
+  // Cleanup timeouts on unmount
+  useEffect(() => {
+    return () => {
+      if (copiedTimeoutRef.current) clearTimeout(copiedTimeoutRef.current);
+      if (copyErrorTimeoutRef.current) clearTimeout(copyErrorTimeoutRef.current);
+    };
+  }, []);
+
+  // Reset state when modal closes
+  useEffect(() => {
+    if (!isOpen) {
+      setStep(existingDevice ? 'config' : 'naming');
+      setSelectedTab('qr');
+      setDeviceNameInput('');
+      setNameError(null);
+      setConfig(null);
+      setIsGenerating(false);
+      setGenerationError(null);
+      setCopied(false);
+      setCopyError(false);
+    }
+  }, [isOpen, existingDevice]);
+
+  // Auto-generate config for existing device
+  useEffect(() => {
+    if (isOpen && existingDevice && !config && !isGenerating && !generationError) {
+      handleGenerateConfig(existingDevice.name);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, existingDevice]);
+
+  const validateDeviceName = (name: string): string | null => {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      return 'Device name is required';
+    }
+    if (trimmed.length > MAX_DEVICE_NAME_LENGTH) {
+      return `Device name must be ${MAX_DEVICE_NAME_LENGTH} characters or less`;
+    }
+    return null;
+  };
+
+  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setDeviceNameInput(value);
+
+    // Clear error when user starts typing
+    if (nameError) {
+      setNameError(null);
+    }
+  };
+
+  const handleGenerateConfig = useCallback(async (name?: string) => {
+    const finalName = name || deviceName.trim();
+
+    // Validate name for new devices
+    if (!existingDevice) {
+      const error = validateDeviceName(finalName);
+      if (error) {
+        setNameError(error);
+        return;
+      }
+    }
+
+    setIsGenerating(true);
+    setGenerationError(null);
+
+    try {
+      // Step 1: Generate keypair
+      const newKeypair = await generateWireGuardKeypair();
+
+      // Step 2: Create auth payload and get config
+      const timestamp = Math.floor(Date.now() / 1000);
+      const challenge = `${clientId}${timestamp}`;
+
+      const signResult = (await signMessage(challenge)) as SignDataResponse;
+
+      const configText = await wireGuardProfile.mutateAsync({
+        client_id: clientId,
+        timestamp,
+        signature: signResult.signature,
+        key: signResult.key,
+        wg_pubkey: newKeypair.publicKey,
+      });
+
+      // Step 3: Replace private key placeholder
+      const finalConfig = configText.replace(
+        PRIVATE_KEY_PLACEHOLDER,
+        newKeypair.privateKey
+      );
+      setConfig(finalConfig);
+
+      // Step 4: Store device name locally
+      setDeviceName(newKeypair.publicKey, finalName);
+
+      // Step 5: Notify parent of new device
+      if (onDeviceCreated && !existingDevice) {
+        const newDevice: WireGuardDevice = {
+          pubkey: newKeypair.publicKey,
+          name: finalName,
+          assignedIp: '', // Will be updated when parent refreshes device list
+          createdAt: new Date().toISOString(),
+        };
+        onDeviceCreated(newDevice);
+      }
+
+      // Move to config step
+      setStep('config');
+    } catch (error) {
+      console.error('Failed to generate config:', error);
+      setGenerationError(
+        error instanceof Error
+          ? error.message
+          : 'Failed to generate configuration. Please try again.'
+      );
+    } finally {
+      setIsGenerating(false);
+    }
+  }, [deviceName, existingDevice, clientId, signMessage, wireGuardProfile, onDeviceCreated]);
+
+  const handleNameSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    handleGenerateConfig();
+  };
+
+  const handleDownload = () => {
+    if (!config) return;
+
+    const finalName = existingDevice?.name || deviceName.trim();
+    const sanitizedName = finalName.replace(/[^a-zA-Z0-9-_]/g, '-').toLowerCase();
+    const sanitizedRegion = regionId.replace(/[^a-zA-Z0-9-_]/g, '-').toLowerCase();
+    const filename = `nabu-${sanitizedRegion}-${sanitizedName}.conf`;
+
+    const blob = new Blob([config], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+
+    // Delay revocation to ensure browser has time to initiate download
+    setTimeout(() => URL.revokeObjectURL(url), 100);
+  };
+
+  const handleCopy = async () => {
+    if (!config) return;
+
+    try {
+      await navigator.clipboard.writeText(config);
+      setCopied(true);
+      setCopyError(false);
+
+      if (copiedTimeoutRef.current) clearTimeout(copiedTimeoutRef.current);
+      copiedTimeoutRef.current = setTimeout(() => setCopied(false), 3000);
+    } catch (error) {
+      console.error('Failed to copy config:', error);
+      setCopyError(true);
+
+      if (copyErrorTimeoutRef.current) clearTimeout(copyErrorTimeoutRef.current);
+      copyErrorTimeoutRef.current = setTimeout(() => setCopyError(false), 3000);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  const modalTitle = step === 'naming'
+    ? 'Add New Device'
+    : existingDevice
+      ? `Config for ${existingDevice.name}`
+      : 'Your WireGuard Config';
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={headingId}
+    >
+      <div
+        ref={modalRef}
+        tabIndex={-1}
+        className="bg-[#1a1a2e] border border-white/20 rounded-2xl shadow-2xl max-w-md w-full max-h-[90vh] overflow-y-auto outline-none"
+      >
+        <div className="p-6 space-y-5">
+          {/* Header */}
+          <div className="flex items-center justify-between">
+            <h2 id={headingId} className="text-xl font-bold text-white">
+              {modalTitle}
+            </h2>
+            <button
+              onClick={onClose}
+              className="p-2 text-white/60 hover:text-white hover:bg-white/10 rounded-lg transition-colors"
+              aria-label="Close"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+
+          {/* Region info */}
+          <div className="text-sm text-white/60">
+            Region: <span className="text-white/80">{regionName}</span>
+          </div>
+
+          {/* Step 1: Device Naming */}
+          {step === 'naming' && (
+            <form onSubmit={handleNameSubmit} className="space-y-4">
+              <div>
+                <label htmlFor="device-name" className="block text-sm font-medium text-white/80 mb-2">
+                  Device Name
+                </label>
+                <input
+                  ref={inputRef}
+                  id="device-name"
+                  type="text"
+                  value={deviceName}
+                  onChange={handleNameChange}
+                  maxLength={MAX_DEVICE_NAME_LENGTH}
+                  placeholder={detectDeviceType()}
+                  className={`w-full px-4 py-3 bg-white/10 border rounded-lg text-white placeholder-white/40 focus:outline-none focus:ring-2 transition-colors ${
+                    nameError
+                      ? 'border-red-400/50 focus:ring-red-400/50'
+                      : 'border-white/20 focus:ring-purple-400/50 focus:border-purple-400/50'
+                  }`}
+                  disabled={isGenerating}
+                />
+                <div className="flex justify-between mt-2">
+                  <span className={`text-xs ${nameError ? 'text-red-400' : 'text-white/50'}`}>
+                    {nameError || `Max ${MAX_DEVICE_NAME_LENGTH} characters`}
+                  </span>
+                  <span className="text-xs text-white/50">
+                    {deviceName.length}/{MAX_DEVICE_NAME_LENGTH}
+                  </span>
+                </div>
+              </div>
+
+              {generationError && (
+                <div className="bg-red-500/20 border border-red-400/30 rounded-lg p-3" role="alert">
+                  <p className="text-sm text-red-200">{generationError}</p>
+                </div>
+              )}
+
+              <div className="flex gap-3 pt-2">
+                <button
+                  type="button"
+                  onClick={onClose}
+                  disabled={isGenerating}
+                  className="flex-1 py-3 px-4 rounded-lg font-medium transition-all bg-white/10 text-white hover:bg-white/20 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={isGenerating}
+                  className="flex-1 py-3 px-4 rounded-lg font-semibold transition-all bg-purple-600 text-white hover:bg-purple-500 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                >
+                  {isGenerating ? (
+                    <>
+                      <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                      Generating...
+                    </>
+                  ) : (
+                    'Generate Config'
+                  )}
+                </button>
+              </div>
+            </form>
+          )}
+
+          {/* Step 2: Config Display */}
+          {step === 'config' && (
+            <div className="space-y-4">
+              {/* Loading state for existing device */}
+              {isGenerating && (
+                <div className="flex flex-col items-center justify-center py-12">
+                  <div className="w-8 h-8 border-2 border-white/30 border-t-white rounded-full animate-spin mb-4" />
+                  <span className="text-white/60">Generating configuration...</span>
+                </div>
+              )}
+
+              {/* Error state */}
+              {generationError && !isGenerating && (
+                <div className="space-y-4">
+                  <div className="bg-red-500/20 border border-red-400/30 rounded-lg p-4" role="alert">
+                    <p className="text-sm text-red-200">{generationError}</p>
+                  </div>
+                  <button
+                    onClick={() => handleGenerateConfig(existingDevice?.name)}
+                    className="w-full py-3 px-4 rounded-lg font-semibold transition-all bg-purple-600 text-white hover:bg-purple-500"
+                  >
+                    Retry
+                  </button>
+                </div>
+              )}
+
+              {/* Config display */}
+              {config && !isGenerating && (
+                <>
+                  {/* Tab buttons */}
+                  <div role="tablist" aria-label="Config delivery method" className="flex rounded-lg bg-white/10 p-1 gap-1">
+                    <button
+                      role="tab"
+                      aria-selected={selectedTab === 'qr'}
+                      aria-controls="tabpanel-qr"
+                      id="tab-qr"
+                      className={`flex-1 py-2 px-3 rounded-md text-sm font-medium transition-all ${
+                        selectedTab === 'qr'
+                          ? 'bg-white text-black'
+                          : 'text-white/70 hover:text-white hover:bg-white/10'
+                      }`}
+                      onClick={() => setSelectedTab('qr')}
+                    >
+                      QR Code
+                    </button>
+                    <button
+                      role="tab"
+                      aria-selected={selectedTab === 'download'}
+                      aria-controls="tabpanel-download"
+                      id="tab-download"
+                      className={`flex-1 py-2 px-3 rounded-md text-sm font-medium transition-all ${
+                        selectedTab === 'download'
+                          ? 'bg-white text-black'
+                          : 'text-white/70 hover:text-white hover:bg-white/10'
+                      }`}
+                      onClick={() => setSelectedTab('download')}
+                    >
+                      Download
+                    </button>
+                    <button
+                      role="tab"
+                      aria-selected={selectedTab === 'copy'}
+                      aria-controls="tabpanel-copy"
+                      id="tab-copy"
+                      className={`flex-1 py-2 px-3 rounded-md text-sm font-medium transition-all ${
+                        selectedTab === 'copy'
+                          ? 'bg-white text-black'
+                          : 'text-white/70 hover:text-white hover:bg-white/10'
+                      }`}
+                      onClick={() => setSelectedTab('copy')}
+                    >
+                      Copy
+                    </button>
+                  </div>
+
+                  {/* QR Code tab */}
+                  {selectedTab === 'qr' && (
+                    <div
+                      role="tabpanel"
+                      id="tabpanel-qr"
+                      aria-labelledby="tab-qr"
+                      className="text-center space-y-4"
+                    >
+                      <div className="inline-block p-4 bg-white rounded-xl">
+                        <QRCodeSVG
+                          value={config}
+                          size={200}
+                          level="L"
+                          includeMargin={false}
+                        />
+                      </div>
+                      <p className="text-sm text-white/60">
+                        Scan this QR code with your WireGuard app to import the configuration automatically.
+                      </p>
+                    </div>
+                  )}
+
+                  {/* Download tab */}
+                  {selectedTab === 'download' && (
+                    <div
+                      role="tabpanel"
+                      id="tabpanel-download"
+                      aria-labelledby="tab-download"
+                      className="text-center space-y-4"
+                    >
+                      <div className="py-8">
+                        <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-purple-500/20 flex items-center justify-center">
+                          <svg className="w-8 h-8 text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                          </svg>
+                        </div>
+                        <p className="text-sm text-white/60 mb-4">
+                          Download the configuration file and import it into your WireGuard app.
+                        </p>
+                        <button
+                          onClick={handleDownload}
+                          className="px-6 py-3 rounded-lg font-semibold transition-all bg-purple-600 text-white hover:bg-purple-500"
+                        >
+                          Download Config File
+                        </button>
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Copy tab */}
+                  {selectedTab === 'copy' && (
+                    <div
+                      role="tabpanel"
+                      id="tabpanel-copy"
+                      aria-labelledby="tab-copy"
+                      className="space-y-4"
+                    >
+                      <p className="text-sm text-white/80 text-center">
+                        Copy the configuration and paste it into your WireGuard app's "Import from text" feature.
+                      </p>
+                      <textarea
+                        readOnly
+                        value={config}
+                        rows={8}
+                        aria-label="WireGuard configuration content"
+                        className="w-full bg-black/30 rounded-lg p-3 text-xs text-white/80 font-mono resize-none border border-white/10 focus:outline-none focus:border-purple-400/50"
+                        onClick={(e) => (e.target as HTMLTextAreaElement).select()}
+                      />
+                      <button
+                        onClick={handleCopy}
+                        className={`w-full py-3 px-4 rounded-lg font-semibold transition-all ${
+                          copyError
+                            ? 'bg-red-500 text-white'
+                            : 'bg-white text-black hover:bg-white/90'
+                        }`}
+                      >
+                        {copyError
+                          ? 'Copy failed - try selecting text manually'
+                          : copied
+                            ? 'Copied!'
+                            : 'Copy Configuration'}
+                      </button>
+                    </div>
+                  )}
+
+                  {/* Done button */}
+                  <div className="pt-2">
+                    <button
+                      onClick={onClose}
+                      className="w-full py-3 px-4 rounded-lg font-medium transition-all bg-white/10 text-white hover:bg-white/20"
+                    >
+                      Done
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default DeviceConfigModal;

--- a/src/components/ProtocolToggle.tsx
+++ b/src/components/ProtocolToggle.tsx
@@ -1,0 +1,162 @@
+import { useState } from 'react';
+
+/**
+ * ProtocolToggle component for switching between WireGuard and OpenVPN protocols.
+ *
+ * Behavior:
+ * - Defaults to WireGuard when VITE_WIREGUARD_ENABLED=true
+ * - Shows "Looking for OpenVPN?" link when VITE_OPENVPN_REGION is set
+ * - When OpenVPN is selected, shows a recommendation banner with a link to switch back
+ * - Banner can be dismissed and preference is saved to localStorage
+ * - When WireGuard is disabled (feature flag off), this component should not be rendered
+ */
+
+export type VpnProtocolType = 'wireguard' | 'openvpn';
+
+const BANNER_DISMISSED_KEY = 'wireguard-recommendation-dismissed';
+
+export interface ProtocolToggleProps {
+  selectedProtocol: VpnProtocolType;
+  onProtocolChange: (protocol: VpnProtocolType) => void;
+}
+
+// Check if WireGuard feature is enabled
+const isWireGuardEnabled = import.meta.env.VITE_WIREGUARD_ENABLED === 'true';
+
+// Get the OpenVPN region identifier (if set, OpenVPN is available)
+const openVpnRegion = import.meta.env.VITE_OPENVPN_REGION;
+
+/**
+ * Helper to check if WireGuard UI should be shown
+ */
+export function shouldShowWireGuardUI(): boolean {
+  return isWireGuardEnabled;
+}
+
+/**
+ * Helper to check if OpenVPN option should be available
+ */
+export function isOpenVpnAvailable(): boolean {
+  return !!openVpnRegion;
+}
+
+/**
+ * Get the OpenVPN region identifier
+ */
+export function getOpenVpnRegion(): string | undefined {
+  return openVpnRegion;
+}
+
+const ProtocolToggle = ({
+  selectedProtocol,
+  onProtocolChange,
+}: ProtocolToggleProps) => {
+  const [bannerDismissed, setBannerDismissed] = useState(() => {
+    try {
+      return localStorage.getItem(BANNER_DISMISSED_KEY) === 'true';
+    } catch {
+      return false;
+    }
+  });
+
+  const handleDismissBanner = () => {
+    setBannerDismissed(true);
+    try {
+      localStorage.setItem(BANNER_DISMISSED_KEY, 'true');
+    } catch {
+      // Ignore localStorage errors
+    }
+  };
+
+  // If WireGuard is not enabled, don't render the toggle
+  // (the parent should handle showing OpenVPN-only flow)
+  if (!isWireGuardEnabled) {
+    return null;
+  }
+
+  const showOpenVpnLink = isOpenVpnAvailable();
+
+  // WireGuard view with "Looking for OpenVPN?" link
+  if (selectedProtocol === 'wireguard') {
+    return (
+      <div className="flex flex-col items-center gap-2 w-full">
+        {showOpenVpnLink && (
+          <button
+            type="button"
+            onClick={() => onProtocolChange('openvpn')}
+            className="text-sm text-[#E1B8FF] hover:text-white transition-colors cursor-pointer underline underline-offset-2"
+          >
+            Looking for OpenVPN?
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  // OpenVPN view with recommendation banner (if not dismissed) or minimal switch link
+  return (
+    <div className="flex flex-col items-center gap-4 w-full">
+      {!bannerDismissed ? (
+        <div className="w-full max-w-2xl rounded-lg bg-blue-500/20 border border-blue-500/40 p-4 relative">
+          <button
+            type="button"
+            onClick={handleDismissBanner}
+            className="absolute top-2 right-2 text-gray-400 hover:text-white transition-colors p-1"
+            aria-label="Dismiss recommendation"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              className="w-5 h-5"
+            >
+              <path
+                fillRule="evenodd"
+                d="M5.47 5.47a.75.75 0 011.06 0L12 10.94l5.47-5.47a.75.75 0 111.06 1.06L13.06 12l5.47 5.47a.75.75 0 11-1.06 1.06L12 13.06l-5.47 5.47a.75.75 0 01-1.06-1.06L10.94 12 5.47 6.53a.75.75 0 010-1.06z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </button>
+          <div className="flex items-start gap-3 pr-6">
+            <span className="text-blue-400 text-xl flex-shrink-0" role="img" aria-label="Info">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                className="w-6 h-6"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12zm8.706-1.442c1.146-.573 2.437.463 2.126 1.706l-.709 2.836.042-.02a.75.75 0 01.67 1.34l-.04.022c-1.147.573-2.438-.463-2.127-1.706l.71-2.836-.042.02a.75.75 0 11-.671-1.34l.041-.022zM12 9a.75.75 0 100-1.5.75.75 0 000 1.5z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </span>
+            <div className="flex flex-col gap-2">
+              <button
+                type="button"
+                onClick={() => onProtocolChange('wireguard')}
+                className="self-start text-sm font-semibold text-[#9400FF] hover:text-[#B44DFF] transition-colors cursor-pointer underline underline-offset-2"
+              >
+                We recommend WireGuard
+              </button>
+              <p className="text-sm text-gray-300">
+                WireGuard offers faster speeds and multi-device support. OpenVPN is provided for compatibility with devices that don't support WireGuard.
+              </p>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => onProtocolChange('wireguard')}
+          className="text-sm text-[#E1B8FF] hover:text-white transition-colors cursor-pointer underline underline-offset-2"
+        >
+          Switch to WireGuard
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default ProtocolToggle;

--- a/src/components/RegionSelect.tsx
+++ b/src/components/RegionSelect.tsx
@@ -1,4 +1,73 @@
+import { useEffect } from "react";
 import Select from "react-select";
+import type { VpnProtocolType } from "./ProtocolToggle";
+
+/**
+ * Map of region IDs to friendly display names.
+ * Format: "Friendly Name (technical-id)"
+ */
+const REGION_FRIENDLY_NAMES: Record<string, string> = {
+  // WireGuard regions
+  "wg-us1": "United States East",
+  "wg-us2": "United States West",
+  "wg-eu1": "Europe (Amsterdam)",
+  "wg-eu2": "Europe (Frankfurt)",
+  "wg-asia1": "Asia Pacific (Singapore)",
+  "wg-asia2": "Asia Pacific (Tokyo)",
+  // Mock WireGuard region for development/testing
+  "dev-us1": "Development US (WireGuard)",
+  // OpenVPN legacy regions (preprod uses spaces in region names)
+  us1: "United States",
+  "us east-1": "United States East",
+  "us east-2": "United States East 2",
+  // Add more mappings as needed
+};
+
+/**
+ * Get the friendly display name for a region.
+ * Returns "Friendly Name (technical-id)" format.
+ */
+function getRegionDisplayName(regionId: string): string {
+  const friendlyName = REGION_FRIENDLY_NAMES[regionId];
+  if (friendlyName) {
+    return `${friendlyName} (${regionId})`;
+  }
+  // Fallback: capitalize and format the region ID
+  return regionId.toUpperCase();
+}
+
+// Get the OpenVPN regions from environment (comma-separated list)
+const openVpnRegionsEnv = import.meta.env.VITE_OPENVPN_REGION || "";
+const openVpnRegions = openVpnRegionsEnv
+  .split(",")
+  .map((r: string) => r.trim())
+  .filter(Boolean);
+
+
+/**
+ * Check if a region is an OpenVPN region
+ */
+function isOpenVpnRegion(region: string): boolean {
+  return openVpnRegions.includes(region);
+}
+
+/**
+ * Filter regions based on the selected protocol.
+ * - For WireGuard: exclude OpenVPN regions (any region not in VITE_OPENVPN_REGION list)
+ * - For OpenVPN: only include OpenVPN regions
+ */
+export function filterRegionsByProtocol(
+  regions: string[],
+  protocol: VpnProtocolType
+): string[] {
+  if (protocol === "openvpn") {
+    // Only show OpenVPN regions
+    return regions.filter(isOpenVpnRegion);
+  }
+
+  // WireGuard: exclude OpenVPN regions
+  return regions.filter((r) => !isOpenVpnRegion(r));
+}
 
 interface RegionSelectProps {
   value: string;
@@ -6,6 +75,8 @@ interface RegionSelectProps {
   regions: string[];
   disabled?: boolean;
   showTooltips?: boolean;
+  /** Protocol filter - when set, filters regions appropriately */
+  protocol?: VpnProtocolType;
 }
 
 const RegionSelect = ({
@@ -14,10 +85,32 @@ const RegionSelect = ({
   regions,
   disabled,
   showTooltips,
+  protocol,
 }: RegionSelectProps) => {
-  const options = regions.map((region) => ({
+  // Filter regions based on protocol if specified
+  const filteredRegions = protocol
+    ? filterRegionsByProtocol(regions, protocol)
+    : regions;
+
+  // Auto-select first region when current value is not in filtered regions
+  // This handles both single-region cases and when value is filtered out by protocol change
+  useEffect(() => {
+    if (filteredRegions.length === 0) {
+      return;
+    }
+    if (!filteredRegions.includes(value)) {
+      onChange(filteredRegions[0]);
+    }
+  }, [filteredRegions, value, onChange]);
+
+  // Hide selector entirely when only 1 region available
+  if (filteredRegions.length <= 1) {
+    return null;
+  }
+
+  const options = filteredRegions.map((region) => ({
     value: region,
-    label: region.toUpperCase(),
+    label: getRegionDisplayName(region),
   }));
 
   const selectedOption =
@@ -25,7 +118,7 @@ const RegionSelect = ({
 
   return (
     <div
-      className="w-48"
+      className="w-full max-w-xs"
       {...(showTooltips && { "data-tooltip-id": "region-tooltip" })}
     >
       <Select

--- a/src/components/WireGuardDeviceList.tsx
+++ b/src/components/WireGuardDeviceList.tsx
@@ -1,0 +1,117 @@
+import type { WireGuardDevice } from "../api/types";
+import { getDeviceIconFromName } from "../utils/deviceDetection";
+import SpinningBorderButton from "./SpinningBorderButton";
+
+interface WireGuardDeviceListProps {
+  devices: WireGuardDevice[];
+  deviceLimit: number;
+  onAddDevice: () => void;
+  onRedownloadConfig: (device: WireGuardDevice) => void;
+  onRegenerateAll: () => void;
+}
+
+/**
+ * Formats an ISO timestamp into a readable date string
+ */
+function formatDate(isoString: string): string {
+  const date = new Date(isoString);
+  if (Number.isNaN(date.getTime())) {
+    return "Unknown";
+  }
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+const WireGuardDeviceList = ({
+  devices,
+  deviceLimit,
+  onAddDevice,
+  onRedownloadConfig,
+  onRegenerateAll,
+}: WireGuardDeviceListProps) => {
+  const deviceCount = devices.length;
+  const canAddDevice = deviceCount < deviceLimit;
+  const isAtLimit = deviceCount >= deviceLimit;
+
+  return (
+    <div className="flex flex-col gap-3 w-full">
+      {/* Device count header */}
+      <div className="flex items-center justify-between">
+        <p className="text-xs md:text-sm font-medium">
+          Devices ({deviceCount}/{deviceLimit})
+        </p>
+      </div>
+
+      {/* Device list */}
+      {devices.length > 0 ? (
+        <div className="flex flex-col gap-2">
+          {devices.map((device) => (
+            <div
+              key={device.pubkey}
+              className="flex flex-col gap-1.5 p-3 rounded-md bg-white/10 backdrop-blur-sm"
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <span className="text-base" role="img" aria-label="device">
+                    {getDeviceIconFromName(device.name)}
+                  </span>
+                  <span className="text-sm font-medium">{device.name}</span>
+                </div>
+              </div>
+              <div className="flex items-center justify-between">
+                <p className="text-xs text-white/70">
+                  Created: {formatDate(device.createdAt)}
+                </p>
+                <button
+                  onClick={() => onRedownloadConfig(device)}
+                  className="text-xs px-2.5 py-1 rounded bg-white/20 hover:bg-white/30 transition-colors cursor-pointer"
+                >
+                  Re-download Config
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-xs text-white/70">No devices registered yet.</p>
+      )}
+
+      {/* Add device or limit reached message */}
+      {canAddDevice ? (
+        <SpinningBorderButton
+          onClick={onAddDevice}
+          className="flex items-center justify-center gap-2 py-1.5 px-3.5 backdrop-blur-xs shadow-sm bg-white text-black hover:bg-white/90 transition-all w-full md:w-auto md:self-start"
+          radius="8px"
+        >
+          <span className="text-black font-semibold text-xs md:text-sm">
+            + Add Device
+          </span>
+        </SpinningBorderButton>
+      ) : isAtLimit ? (
+        <div className="flex flex-col gap-2 p-3 rounded-md bg-white/10 backdrop-blur-sm">
+          <p className="text-xs text-white/80">
+            Device limit reached ({deviceLimit}/{deviceLimit}). To add a new device, you can
+            regenerate all configurations which will remove existing devices.
+          </p>
+        </div>
+      ) : null}
+
+      {/* Regenerate all button - always visible when there are devices */}
+      {devices.length > 0 && (
+        <div className="flex justify-end pt-1">
+          <button
+            onClick={onRegenerateAll}
+            className="text-xs px-3 py-1.5 rounded bg-white/20 hover:bg-white/30 transition-colors cursor-pointer"
+          >
+            Regenerate All Configs
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default WireGuardDeviceList;

--- a/src/components/__tests__/DeviceConfigModal.test.tsx
+++ b/src/components/__tests__/DeviceConfigModal.test.tsx
@@ -1,0 +1,403 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { renderWithProviders, userEvent } from "../../test/utils";
+import { DeviceConfigModal } from "../DeviceConfigModal";
+
+// Mock the wallet store
+const mockSignMessage = vi.fn();
+vi.mock("../../stores/walletStore", () => ({
+  useWalletStore: () => ({
+    signMessage: mockSignMessage,
+  }),
+}));
+
+// Mock the WireGuard profile hook
+const mockMutateAsync = vi.fn();
+vi.mock("../../api/hooks/useWireGuard", () => ({
+  useWireGuardProfile: () => ({
+    mutateAsync: mockMutateAsync,
+    isPending: false,
+  }),
+}));
+
+// Mock device detection
+vi.mock("../../utils/deviceDetection", () => ({
+  detectDeviceType: () => "Desktop",
+}));
+
+// Mock keypair generation
+vi.mock("../../utils/wireguardKeys", () => ({
+  generateWireGuardKeypair: () =>
+    Promise.resolve({
+      publicKey: "test-public-key-base64",
+      privateKey: "test-private-key-base64",
+    }),
+}));
+
+// Mock device name storage
+vi.mock("../../utils/deviceNames", () => ({
+  setDeviceName: vi.fn(),
+  getDeviceName: vi.fn(),
+}));
+
+describe("DeviceConfigModal", () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    clientId: "test-client-id",
+    regionName: "United States East",
+    regionId: "wg-us1",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSignMessage.mockResolvedValue({
+      signature: "mock-signature",
+      key: "mock-key",
+    });
+    mockMutateAsync.mockResolvedValue(
+      "[Interface]\nPrivateKey = <REPLACE_WITH_YOUR_PRIVATE_KEY>\nAddress = 10.8.0.2/32\n\n[Peer]\nPublicKey = server-key\nEndpoint = vpn.example.com:51820\nAllowedIPs = 0.0.0.0/0",
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("rendering", () => {
+    it("should not render when isOpen is false", () => {
+      renderWithProviders(
+        <DeviceConfigModal {...defaultProps} isOpen={false} />,
+      );
+
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    it("should render when isOpen is true", () => {
+      renderWithProviders(<DeviceConfigModal {...defaultProps} />);
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    it("should show naming step for new devices", () => {
+      renderWithProviders(<DeviceConfigModal {...defaultProps} />);
+
+      expect(screen.getByText("Add New Device")).toBeInTheDocument();
+      expect(screen.getByLabelText(/device name/i)).toBeInTheDocument();
+    });
+
+    it("should show default device name from detection", () => {
+      renderWithProviders(<DeviceConfigModal {...defaultProps} />);
+
+      const input = screen.getByLabelText(/device name/i) as HTMLInputElement;
+      expect(input.value).toBe("Desktop");
+    });
+
+    it("should show config step for existing device", async () => {
+      const existingDevice = {
+        pubkey: "existing-pubkey",
+        name: "My iPhone",
+        assignedIp: "10.8.0.5",
+        createdAt: new Date().toISOString(),
+      };
+
+      renderWithProviders(
+        <DeviceConfigModal {...defaultProps} existingDevice={existingDevice} />,
+      );
+
+      // Should show the device name in the title
+      await waitFor(() => {
+        expect(
+          screen.getByText(/config for my iphone/i),
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("device naming", () => {
+    it("should allow changing device name", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<DeviceConfigModal {...defaultProps} />);
+
+      const input = screen.getByLabelText(/device name/i);
+      await user.clear(input);
+      await user.type(input, "My Custom Device");
+
+      expect(input).toHaveValue("My Custom Device");
+    });
+
+    it("should show error for empty device name", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<DeviceConfigModal {...defaultProps} />);
+
+      const input = screen.getByLabelText(/device name/i);
+      await user.clear(input);
+
+      const generateButton = screen.getByRole("button", {
+        name: /generate config/i,
+      });
+      await user.click(generateButton);
+
+      expect(screen.getByText(/device name is required/i)).toBeInTheDocument();
+    });
+
+    it("should respect maxLength attribute and show character count at limit", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<DeviceConfigModal {...defaultProps} />);
+
+      const input = screen.getByLabelText(/device name/i) as HTMLInputElement;
+      await user.clear(input);
+      // Note: input has maxLength=32, so typing 33 chars results in 32 chars
+      // The validation happens server-side or we need to test the validation function directly
+      await user.type(input, "a".repeat(32)); // Type exactly 32 chars (max allowed by input)
+
+      // Verify input respects maxLength
+      expect(input.value.length).toBe(32);
+      expect(screen.getByText(/32\/32/)).toBeInTheDocument();
+    });
+
+    it("should show character count", () => {
+      renderWithProviders(<DeviceConfigModal {...defaultProps} />);
+
+      // "Desktop" is 7 characters
+      expect(screen.getByText(/7\/32/)).toBeInTheDocument();
+    });
+  });
+
+  describe("config generation", () => {
+    it("should generate config when button is clicked", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<DeviceConfigModal {...defaultProps} />);
+
+      const generateButton = screen.getByRole("button", {
+        name: /generate config/i,
+      });
+      await user.click(generateButton);
+
+      await waitFor(() => {
+        expect(mockMutateAsync).toHaveBeenCalled();
+      });
+    });
+
+    it("should replace private key placeholder in config", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<DeviceConfigModal {...defaultProps} />);
+
+      const generateButton = screen.getByRole("button", {
+        name: /generate config/i,
+      });
+      await user.click(generateButton);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/your wireguard config/i),
+        ).toBeInTheDocument();
+      });
+
+      // Switch to copy tab to see config text
+      const copyTab = screen.getByRole("tab", { name: /copy/i });
+      await user.click(copyTab);
+
+      // Should not contain the placeholder
+      expect(
+        screen.queryByText(/<REPLACE_WITH_YOUR_PRIVATE_KEY>/),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should show error when generation fails", async () => {
+      mockMutateAsync.mockRejectedValueOnce(new Error("Network error"));
+
+      const user = userEvent.setup();
+      renderWithProviders(<DeviceConfigModal {...defaultProps} />);
+
+      const generateButton = screen.getByRole("button", {
+        name: /generate config/i,
+      });
+      await user.click(generateButton);
+
+      // The component shows the error message from the Error object
+      await waitFor(() => {
+        expect(screen.getByText(/network error/i)).toBeInTheDocument();
+      });
+    });
+
+    it("should call onDeviceCreated callback for new devices", async () => {
+      const onDeviceCreated = vi.fn();
+      const user = userEvent.setup();
+
+      renderWithProviders(
+        <DeviceConfigModal
+          {...defaultProps}
+          onDeviceCreated={onDeviceCreated}
+        />,
+      );
+
+      const generateButton = screen.getByRole("button", {
+        name: /generate config/i,
+      });
+      await user.click(generateButton);
+
+      await waitFor(() => {
+        expect(onDeviceCreated).toHaveBeenCalledWith(
+          expect.objectContaining({
+            pubkey: "test-public-key-base64",
+            name: "Desktop",
+          }),
+        );
+      });
+    });
+  });
+
+  describe("config display", () => {
+    it("should show QR code tab by default", async () => {
+      const existingDevice = {
+        pubkey: "existing-pubkey",
+        name: "Test Device",
+        assignedIp: "10.8.0.5",
+        createdAt: new Date().toISOString(),
+      };
+
+      renderWithProviders(
+        <DeviceConfigModal {...defaultProps} existingDevice={existingDevice} />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole("tab", { name: /qr code/i })).toHaveAttribute(
+          "aria-selected",
+          "true",
+        );
+      });
+    });
+
+    it("should switch between tabs", async () => {
+      const user = userEvent.setup();
+      const existingDevice = {
+        pubkey: "existing-pubkey",
+        name: "Test Device",
+        assignedIp: "10.8.0.5",
+        createdAt: new Date().toISOString(),
+      };
+
+      renderWithProviders(
+        <DeviceConfigModal {...defaultProps} existingDevice={existingDevice} />,
+      );
+
+      // For existing devices, the title is "Config for {name}"
+      await waitFor(() => {
+        expect(
+          screen.getByText(/config for test device/i),
+        ).toBeInTheDocument();
+      });
+
+      // Click Download tab
+      const downloadTab = screen.getByRole("tab", { name: /download/i });
+      await user.click(downloadTab);
+      expect(downloadTab).toHaveAttribute("aria-selected", "true");
+
+      // Click Copy tab
+      const copyTab = screen.getByRole("tab", { name: /copy/i });
+      await user.click(copyTab);
+      expect(copyTab).toHaveAttribute("aria-selected", "true");
+    });
+
+    it("should show download button with correct filename", async () => {
+      const user = userEvent.setup();
+      const existingDevice = {
+        pubkey: "existing-pubkey",
+        name: "My iPhone",
+        assignedIp: "10.8.0.5",
+        createdAt: new Date().toISOString(),
+      };
+
+      renderWithProviders(
+        <DeviceConfigModal {...defaultProps} existingDevice={existingDevice} />,
+      );
+
+      // For existing devices, the title is "Config for {name}"
+      await waitFor(() => {
+        expect(
+          screen.getByText(/config for my iphone/i),
+        ).toBeInTheDocument();
+      });
+
+      const downloadTab = screen.getByRole("tab", { name: /download/i });
+      await user.click(downloadTab);
+
+      // Download tab shows a button to download, not the filename directly in text
+      // The filename is generated when clicking the button
+      expect(screen.getByRole("button", { name: /download config file/i })).toBeInTheDocument();
+    });
+  });
+
+  describe("modal behavior", () => {
+    it("should close when close button is clicked", async () => {
+      const onClose = vi.fn();
+      const user = userEvent.setup();
+
+      renderWithProviders(
+        <DeviceConfigModal {...defaultProps} onClose={onClose} />,
+      );
+
+      const closeButton = screen.getByRole("button", { name: /close/i });
+      await user.click(closeButton);
+
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it("should close when Escape key is pressed", async () => {
+      const onClose = vi.fn();
+      const user = userEvent.setup();
+
+      renderWithProviders(
+        <DeviceConfigModal {...defaultProps} onClose={onClose} />,
+      );
+
+      await user.keyboard("{Escape}");
+
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it("should have correct ARIA attributes", () => {
+      renderWithProviders(<DeviceConfigModal {...defaultProps} />);
+
+      const dialog = screen.getByRole("dialog");
+      expect(dialog).toHaveAttribute("aria-modal", "true");
+      expect(dialog).toHaveAttribute("aria-labelledby");
+    });
+  });
+
+  describe("copy functionality", () => {
+    it("should show copy tab with config textarea and copy button", async () => {
+      const user = userEvent.setup();
+
+      const existingDevice = {
+        pubkey: "existing-pubkey",
+        name: "Test Device",
+        assignedIp: "10.8.0.5",
+        createdAt: new Date().toISOString(),
+      };
+
+      renderWithProviders(
+        <DeviceConfigModal {...defaultProps} existingDevice={existingDevice} />,
+      );
+
+      // For existing devices, the title is "Config for {name}"
+      await waitFor(() => {
+        expect(
+          screen.getByText(/config for test device/i),
+        ).toBeInTheDocument();
+      });
+
+      const copyTab = screen.getByRole("tab", { name: /copy/i });
+      await user.click(copyTab);
+
+      // Should show textarea with config content
+      const textarea = screen.getByLabelText(/wireguard configuration content/i);
+      expect(textarea).toBeInTheDocument();
+
+      // Should show copy button
+      const copyButton = screen.getByRole("button", { name: /copy configuration/i });
+      expect(copyButton).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/__tests__/ProtocolToggle.test.tsx
+++ b/src/components/__tests__/ProtocolToggle.test.tsx
@@ -1,0 +1,380 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders, userEvent } from "../../test/utils";
+
+// We need to mock import.meta.env before importing the component
+// Since the module reads env vars at import time, we'll use vi.stubEnv
+
+describe("ProtocolToggle", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    vi.unstubAllEnvs();
+    localStorage.clear();
+  });
+
+  describe("when WireGuard is enabled", () => {
+    beforeEach(() => {
+      vi.stubEnv("VITE_WIREGUARD_ENABLED", "true");
+    });
+
+    describe("and OpenVPN region is set", () => {
+      beforeEach(() => {
+        vi.stubEnv("VITE_OPENVPN_REGION", "us-east-1");
+      });
+
+      it("should render WireGuard selected by default and show OpenVPN link", async () => {
+        vi.resetModules();
+        const { default: ProtocolToggle } = await import("../ProtocolToggle");
+
+        const onProtocolChange = vi.fn();
+        renderWithProviders(
+          <ProtocolToggle
+            selectedProtocol="wireguard"
+            onProtocolChange={onProtocolChange}
+          />,
+        );
+
+        expect(
+          screen.getByText(/looking for openvpn\?/i),
+        ).toBeInTheDocument();
+      });
+
+      it("should call onProtocolChange with 'openvpn' when clicking OpenVPN link", async () => {
+        vi.resetModules();
+        const { default: ProtocolToggle } = await import("../ProtocolToggle");
+
+        const onProtocolChange = vi.fn();
+        const user = userEvent.setup();
+
+        renderWithProviders(
+          <ProtocolToggle
+            selectedProtocol="wireguard"
+            onProtocolChange={onProtocolChange}
+          />,
+        );
+
+        const openVpnLink = screen.getByText(/looking for openvpn\?/i);
+        await user.click(openVpnLink);
+
+        expect(onProtocolChange).toHaveBeenCalledWith("openvpn");
+      });
+
+      it("should show recommendation banner when OpenVPN is selected", async () => {
+        vi.resetModules();
+        const { default: ProtocolToggle } = await import("../ProtocolToggle");
+
+        const onProtocolChange = vi.fn();
+        renderWithProviders(
+          <ProtocolToggle
+            selectedProtocol="openvpn"
+            onProtocolChange={onProtocolChange}
+          />,
+        );
+
+        expect(
+          screen.getByText(/we recommend wireguard/i),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByText(/openvpn is provided for compatibility/i),
+        ).toBeInTheDocument();
+      });
+
+      it("should show 'We recommend WireGuard' button when OpenVPN is selected", async () => {
+        vi.resetModules();
+        const { default: ProtocolToggle } = await import("../ProtocolToggle");
+
+        const onProtocolChange = vi.fn();
+        renderWithProviders(
+          <ProtocolToggle
+            selectedProtocol="openvpn"
+            onProtocolChange={onProtocolChange}
+          />,
+        );
+
+        expect(
+          screen.getByRole("button", { name: /we recommend wireguard/i }),
+        ).toBeInTheDocument();
+      });
+
+      it("should call onProtocolChange with 'wireguard' when clicking We recommend WireGuard", async () => {
+        vi.resetModules();
+        const { default: ProtocolToggle } = await import("../ProtocolToggle");
+
+        const onProtocolChange = vi.fn();
+        const user = userEvent.setup();
+
+        renderWithProviders(
+          <ProtocolToggle
+            selectedProtocol="openvpn"
+            onProtocolChange={onProtocolChange}
+          />,
+        );
+
+        const switchButton = screen.getByRole("button", {
+          name: /we recommend wireguard/i,
+        });
+        await user.click(switchButton);
+
+        expect(onProtocolChange).toHaveBeenCalledWith("wireguard");
+      });
+
+      it("should show dismiss button on recommendation banner", async () => {
+        vi.resetModules();
+        localStorage.clear();
+        const { default: ProtocolToggle } = await import("../ProtocolToggle");
+
+        const onProtocolChange = vi.fn();
+        renderWithProviders(
+          <ProtocolToggle
+            selectedProtocol="openvpn"
+            onProtocolChange={onProtocolChange}
+          />,
+        );
+
+        expect(
+          screen.getByRole("button", { name: /dismiss recommendation/i }),
+        ).toBeInTheDocument();
+      });
+
+      it("should hide banner when dismiss button is clicked", async () => {
+        vi.resetModules();
+        localStorage.clear();
+        const { default: ProtocolToggle } = await import("../ProtocolToggle");
+
+        const onProtocolChange = vi.fn();
+        const user = userEvent.setup();
+
+        renderWithProviders(
+          <ProtocolToggle
+            selectedProtocol="openvpn"
+            onProtocolChange={onProtocolChange}
+          />,
+        );
+
+        const dismissButton = screen.getByRole("button", {
+          name: /dismiss recommendation/i,
+        });
+        await user.click(dismissButton);
+
+        expect(
+          screen.queryByText(/we recommend wireguard/i),
+        ).not.toBeInTheDocument();
+      });
+
+      it("should persist banner dismissal in localStorage", async () => {
+        vi.resetModules();
+        localStorage.clear();
+        const { default: ProtocolToggle } = await import("../ProtocolToggle");
+
+        const onProtocolChange = vi.fn();
+        const user = userEvent.setup();
+
+        renderWithProviders(
+          <ProtocolToggle
+            selectedProtocol="openvpn"
+            onProtocolChange={onProtocolChange}
+          />,
+        );
+
+        const dismissButton = screen.getByRole("button", {
+          name: /dismiss recommendation/i,
+        });
+        await user.click(dismissButton);
+
+        expect(localStorage.getItem("wireguard-recommendation-dismissed")).toBe(
+          "true",
+        );
+      });
+
+      it("should not show banner if previously dismissed", async () => {
+        vi.resetModules();
+        localStorage.setItem("wireguard-recommendation-dismissed", "true");
+        const { default: ProtocolToggle } = await import("../ProtocolToggle");
+
+        const onProtocolChange = vi.fn();
+        renderWithProviders(
+          <ProtocolToggle
+            selectedProtocol="openvpn"
+            onProtocolChange={onProtocolChange}
+          />,
+        );
+
+        expect(
+          screen.queryByText(/we recommend wireguard/i),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    describe("and OpenVPN region is not set", () => {
+      beforeEach(() => {
+        vi.stubEnv("VITE_OPENVPN_REGION", "");
+      });
+
+      it("should not show 'Looking for OpenVPN?' link", async () => {
+        vi.resetModules();
+        const { default: ProtocolToggle } = await import("../ProtocolToggle");
+
+        const onProtocolChange = vi.fn();
+        renderWithProviders(
+          <ProtocolToggle
+            selectedProtocol="wireguard"
+            onProtocolChange={onProtocolChange}
+          />,
+        );
+
+        expect(
+          screen.queryByText(/looking for openvpn\?/i),
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("when WireGuard is disabled", () => {
+    beforeEach(() => {
+      vi.stubEnv("VITE_WIREGUARD_ENABLED", "false");
+    });
+
+    it("should return null (not render anything)", async () => {
+      vi.resetModules();
+      const { default: ProtocolToggle } = await import("../ProtocolToggle");
+
+      const onProtocolChange = vi.fn();
+      const { container } = renderWithProviders(
+        <ProtocolToggle
+          selectedProtocol="wireguard"
+          onProtocolChange={onProtocolChange}
+        />,
+      );
+
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe("helper functions", () => {
+    describe("shouldShowWireGuardUI", () => {
+      it("should return true when VITE_WIREGUARD_ENABLED is 'true'", async () => {
+        vi.stubEnv("VITE_WIREGUARD_ENABLED", "true");
+        vi.resetModules();
+        const { shouldShowWireGuardUI } = await import("../ProtocolToggle");
+
+        expect(shouldShowWireGuardUI()).toBe(true);
+      });
+
+      it("should return false when VITE_WIREGUARD_ENABLED is not 'true'", async () => {
+        vi.stubEnv("VITE_WIREGUARD_ENABLED", "false");
+        vi.resetModules();
+        const { shouldShowWireGuardUI } = await import("../ProtocolToggle");
+
+        expect(shouldShowWireGuardUI()).toBe(false);
+      });
+    });
+
+    describe("isOpenVpnAvailable", () => {
+      it("should return true when VITE_OPENVPN_REGION is set", async () => {
+        vi.stubEnv("VITE_OPENVPN_REGION", "us-east-1");
+        vi.resetModules();
+        const { isOpenVpnAvailable } = await import("../ProtocolToggle");
+
+        expect(isOpenVpnAvailable()).toBe(true);
+      });
+
+      it("should return false when VITE_OPENVPN_REGION is empty", async () => {
+        vi.stubEnv("VITE_OPENVPN_REGION", "");
+        vi.resetModules();
+        const { isOpenVpnAvailable } = await import("../ProtocolToggle");
+
+        expect(isOpenVpnAvailable()).toBe(false);
+      });
+
+      it("should return false when VITE_OPENVPN_REGION is undefined", async () => {
+        vi.unstubAllEnvs();
+        vi.resetModules();
+        const { isOpenVpnAvailable } = await import("../ProtocolToggle");
+
+        expect(isOpenVpnAvailable()).toBe(false);
+      });
+    });
+
+    describe("getOpenVpnRegion", () => {
+      it("should return the region when set", async () => {
+        vi.stubEnv("VITE_OPENVPN_REGION", "eu-west-1");
+        vi.resetModules();
+        const { getOpenVpnRegion } = await import("../ProtocolToggle");
+
+        expect(getOpenVpnRegion()).toBe("eu-west-1");
+      });
+
+      it("should return undefined when not set", async () => {
+        vi.unstubAllEnvs();
+        vi.resetModules();
+        const { getOpenVpnRegion } = await import("../ProtocolToggle");
+
+        expect(getOpenVpnRegion()).toBeUndefined();
+      });
+    });
+  });
+
+  describe("UI styling", () => {
+    beforeEach(() => {
+      vi.stubEnv("VITE_WIREGUARD_ENABLED", "true");
+      vi.stubEnv("VITE_OPENVPN_REGION", "us-east-1");
+    });
+
+    it("should have correct styling for OpenVPN link", async () => {
+      vi.resetModules();
+      const { default: ProtocolToggle } = await import("../ProtocolToggle");
+
+      const onProtocolChange = vi.fn();
+      renderWithProviders(
+        <ProtocolToggle
+          selectedProtocol="wireguard"
+          onProtocolChange={onProtocolChange}
+        />,
+      );
+
+      const link = screen.getByText(/looking for openvpn\?/i);
+      expect(link).toHaveClass("text-sm");
+      expect(link).toHaveClass("underline");
+    });
+
+    it("should render info icon in recommendation banner", async () => {
+      vi.resetModules();
+      localStorage.clear();
+      const { default: ProtocolToggle } = await import("../ProtocolToggle");
+
+      const onProtocolChange = vi.fn();
+      renderWithProviders(
+        <ProtocolToggle
+          selectedProtocol="openvpn"
+          onProtocolChange={onProtocolChange}
+        />,
+      );
+
+      const infoIcon = screen.getByRole("img", { name: /info/i });
+      expect(infoIcon).toBeInTheDocument();
+    });
+
+    it("should have blue styling for recommendation banner", async () => {
+      vi.resetModules();
+      localStorage.clear();
+      const { default: ProtocolToggle } = await import("../ProtocolToggle");
+
+      const onProtocolChange = vi.fn();
+      renderWithProviders(
+        <ProtocolToggle
+          selectedProtocol="openvpn"
+          onProtocolChange={onProtocolChange}
+        />,
+      );
+
+      const banner = screen
+        .getByText(/openvpn is provided for compatibility/i)
+        .closest("div");
+      // Check parent container has blue styling
+      const container = banner?.parentElement?.parentElement;
+      expect(container).toHaveClass("bg-blue-500/20");
+      expect(container).toHaveClass("border-blue-500/40");
+    });
+  });
+});

--- a/src/components/__tests__/WireGuardDeviceList.test.tsx
+++ b/src/components/__tests__/WireGuardDeviceList.test.tsx
@@ -1,0 +1,447 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders, userEvent } from "../../test/utils";
+import WireGuardDeviceList from "../WireGuardDeviceList";
+import type { WireGuardDevice } from "../../api/types";
+
+// Mock the deviceDetection utility
+vi.mock("../../utils/deviceDetection", () => ({
+  getDeviceIconFromName: vi.fn((name: string) => {
+    if (name.toLowerCase().includes("iphone")) return "\u{1F4F1}";
+    if (name.toLowerCase().includes("mac")) return "\u{1F4BB}";
+    return "\u{1F5A5}";
+  }),
+}));
+
+describe("WireGuardDeviceList", () => {
+  const mockOnAddDevice = vi.fn();
+  const mockOnRedownloadConfig = vi.fn();
+  const mockOnRegenerateAll = vi.fn();
+
+  const createMockDevice = (
+    overrides: Partial<WireGuardDevice> = {},
+  ): WireGuardDevice => ({
+    pubkey: `pubkey-${Math.random().toString(36).slice(2)}`,
+    name: "Test Device",
+    assignedIp: "10.8.0.2",
+    createdAt: "2024-01-15T12:00:00.000Z",
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("device count display", () => {
+    it("should render device count correctly with no devices", () => {
+      renderWithProviders(
+        <WireGuardDeviceList
+          devices={[]}
+          deviceLimit={3}
+          onAddDevice={mockOnAddDevice}
+          onRedownloadConfig={mockOnRedownloadConfig}
+          onRegenerateAll={mockOnRegenerateAll}
+        />,
+      );
+
+      expect(screen.getByText("Devices (0/3)")).toBeInTheDocument();
+    });
+
+    it("should render device count correctly with some devices", () => {
+      const devices = [createMockDevice(), createMockDevice()];
+
+      renderWithProviders(
+        <WireGuardDeviceList
+          devices={devices}
+          deviceLimit={3}
+          onAddDevice={mockOnAddDevice}
+          onRedownloadConfig={mockOnRedownloadConfig}
+          onRegenerateAll={mockOnRegenerateAll}
+        />,
+      );
+
+      expect(screen.getByText("Devices (2/3)")).toBeInTheDocument();
+    });
+
+    it("should render device count correctly when at limit", () => {
+      const devices = [
+        createMockDevice(),
+        createMockDevice(),
+        createMockDevice(),
+      ];
+
+      renderWithProviders(
+        <WireGuardDeviceList
+          devices={devices}
+          deviceLimit={3}
+          onAddDevice={mockOnAddDevice}
+          onRedownloadConfig={mockOnRedownloadConfig}
+          onRegenerateAll={mockOnRegenerateAll}
+        />,
+      );
+
+      expect(screen.getByText("Devices (3/3)")).toBeInTheDocument();
+    });
+  });
+
+  describe("device list rendering", () => {
+    it("should show 'No devices registered yet' when devices array is empty", () => {
+      renderWithProviders(
+        <WireGuardDeviceList
+          devices={[]}
+          deviceLimit={3}
+          onAddDevice={mockOnAddDevice}
+          onRedownloadConfig={mockOnRedownloadConfig}
+          onRegenerateAll={mockOnRegenerateAll}
+        />,
+      );
+
+      expect(
+        screen.getByText("No devices registered yet."),
+      ).toBeInTheDocument();
+    });
+
+    it("should render devices with names", () => {
+      const devices = [
+        createMockDevice({ name: "My iPhone" }),
+        createMockDevice({ name: "MacBook Pro" }),
+      ];
+
+      renderWithProviders(
+        <WireGuardDeviceList
+          devices={devices}
+          deviceLimit={3}
+          onAddDevice={mockOnAddDevice}
+          onRedownloadConfig={mockOnRedownloadConfig}
+          onRegenerateAll={mockOnRegenerateAll}
+        />,
+      );
+
+      expect(screen.getByText("My iPhone")).toBeInTheDocument();
+      expect(screen.getByText("MacBook Pro")).toBeInTheDocument();
+    });
+
+    it("should render devices with formatted dates", () => {
+      const devices = [
+        createMockDevice({ createdAt: "2024-01-15T12:00:00.000Z" }),
+        createMockDevice({ createdAt: "2024-06-20T08:30:00.000Z" }),
+      ];
+
+      renderWithProviders(
+        <WireGuardDeviceList
+          devices={devices}
+          deviceLimit={3}
+          onAddDevice={mockOnAddDevice}
+          onRedownloadConfig={mockOnRedownloadConfig}
+          onRegenerateAll={mockOnRegenerateAll}
+        />,
+      );
+
+      expect(screen.getByText(/Created: Jan 15, 2024/)).toBeInTheDocument();
+      expect(screen.getByText(/Created: Jun 20, 2024/)).toBeInTheDocument();
+    });
+
+    it("should render device icons based on device name", () => {
+      const devices = [
+        createMockDevice({ name: "My iPhone" }),
+        createMockDevice({ name: "MacBook Pro" }),
+      ];
+
+      renderWithProviders(
+        <WireGuardDeviceList
+          devices={devices}
+          deviceLimit={3}
+          onAddDevice={mockOnAddDevice}
+          onRedownloadConfig={mockOnRedownloadConfig}
+          onRegenerateAll={mockOnRegenerateAll}
+        />,
+      );
+
+      // Check that device icons are rendered
+      const deviceIcons = screen.getAllByRole("img", { name: /device/i });
+      expect(deviceIcons).toHaveLength(2);
+    });
+
+    it("should handle invalid date gracefully", () => {
+      const devices = [createMockDevice({ createdAt: "invalid-date" })];
+
+      renderWithProviders(
+        <WireGuardDeviceList
+          devices={devices}
+          deviceLimit={3}
+          onAddDevice={mockOnAddDevice}
+          onRedownloadConfig={mockOnRedownloadConfig}
+          onRegenerateAll={mockOnRegenerateAll}
+        />,
+      );
+
+      // The formatDate function returns "Unknown" for invalid dates
+      expect(screen.getByText(/Created: Unknown/)).toBeInTheDocument();
+    });
+  });
+
+  describe("Add Device button", () => {
+    it("should render 'Add Device' button when below device limit", () => {
+      renderWithProviders(
+        <WireGuardDeviceList
+          devices={[createMockDevice()]}
+          deviceLimit={3}
+          onAddDevice={mockOnAddDevice}
+          onRedownloadConfig={mockOnRedownloadConfig}
+          onRegenerateAll={mockOnRegenerateAll}
+        />,
+      );
+
+      expect(screen.getByText("+ Add Device")).toBeInTheDocument();
+    });
+
+    it("should call onAddDevice when Add Device button is clicked", async () => {
+      const user = userEvent.setup();
+
+      renderWithProviders(
+        <WireGuardDeviceList
+          devices={[]}
+          deviceLimit={3}
+          onAddDevice={mockOnAddDevice}
+          onRedownloadConfig={mockOnRedownloadConfig}
+          onRegenerateAll={mockOnRegenerateAll}
+        />,
+      );
+
+      const addButton = screen.getByText("+ Add Device");
+      await user.click(addButton);
+
+      expect(mockOnAddDevice).toHaveBeenCalledTimes(1);
+    });
+
+    it("should hide 'Add Device' button when at device limit", () => {
+      const devices = [
+        createMockDevice(),
+        createMockDevice(),
+        createMockDevice(),
+      ];
+
+      renderWithProviders(
+        <WireGuardDeviceList
+          devices={devices}
+          deviceLimit={3}
+          onAddDevice={mockOnAddDevice}
+          onRedownloadConfig={mockOnRedownloadConfig}
+          onRegenerateAll={mockOnRegenerateAll}
+        />,
+      );
+
+      expect(screen.queryByText("+ Add Device")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("device limit message", () => {
+    it("should show device limit message when at limit", () => {
+      const devices = [
+        createMockDevice(),
+        createMockDevice(),
+        createMockDevice(),
+      ];
+
+      renderWithProviders(
+        <WireGuardDeviceList
+          devices={devices}
+          deviceLimit={3}
+          onAddDevice={mockOnAddDevice}
+          onRedownloadConfig={mockOnRedownloadConfig}
+          onRegenerateAll={mockOnRegenerateAll}
+        />,
+      );
+
+      expect(screen.getByText(/Device limit reached/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/regenerate all configurations/i),
+      ).toBeInTheDocument();
+    });
+
+    it("should not show device limit message when below limit", () => {
+      renderWithProviders(
+        <WireGuardDeviceList
+          devices={[createMockDevice()]}
+          deviceLimit={3}
+          onAddDevice={mockOnAddDevice}
+          onRedownloadConfig={mockOnRedownloadConfig}
+          onRegenerateAll={mockOnRegenerateAll}
+        />,
+      );
+
+      expect(screen.queryByText(/Device limit reached/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Re-download Config button", () => {
+    it("should render 'Re-download Config' button for each device", () => {
+      const devices = [createMockDevice(), createMockDevice()];
+
+      renderWithProviders(
+        <WireGuardDeviceList
+          devices={devices}
+          deviceLimit={3}
+          onAddDevice={mockOnAddDevice}
+          onRedownloadConfig={mockOnRedownloadConfig}
+          onRegenerateAll={mockOnRegenerateAll}
+        />,
+      );
+
+      const redownloadButtons = screen.getAllByText("Re-download Config");
+      expect(redownloadButtons).toHaveLength(2);
+    });
+
+    it("should call onRedownloadConfig with correct device when clicked", async () => {
+      const user = userEvent.setup();
+      const device1 = createMockDevice({ name: "Device 1", pubkey: "pk1" });
+      const device2 = createMockDevice({ name: "Device 2", pubkey: "pk2" });
+
+      renderWithProviders(
+        <WireGuardDeviceList
+          devices={[device1, device2]}
+          deviceLimit={3}
+          onAddDevice={mockOnAddDevice}
+          onRedownloadConfig={mockOnRedownloadConfig}
+          onRegenerateAll={mockOnRegenerateAll}
+        />,
+      );
+
+      const redownloadButtons = screen.getAllByText("Re-download Config");
+      await user.click(redownloadButtons[0]);
+
+      expect(mockOnRedownloadConfig).toHaveBeenCalledWith(device1);
+    });
+  });
+
+  describe("Regenerate All Configs button", () => {
+    it("should render 'Regenerate All Configs' button when there are devices", () => {
+      renderWithProviders(
+        <WireGuardDeviceList
+          devices={[createMockDevice()]}
+          deviceLimit={3}
+          onAddDevice={mockOnAddDevice}
+          onRedownloadConfig={mockOnRedownloadConfig}
+          onRegenerateAll={mockOnRegenerateAll}
+        />,
+      );
+
+      expect(screen.getByText("Regenerate All Configs")).toBeInTheDocument();
+    });
+
+    it("should not render 'Regenerate All Configs' button when no devices", () => {
+      renderWithProviders(
+        <WireGuardDeviceList
+          devices={[]}
+          deviceLimit={3}
+          onAddDevice={mockOnAddDevice}
+          onRedownloadConfig={mockOnRedownloadConfig}
+          onRegenerateAll={mockOnRegenerateAll}
+        />,
+      );
+
+      expect(
+        screen.queryByText("Regenerate All Configs"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should call onRegenerateAll when clicked", async () => {
+      const user = userEvent.setup();
+
+      renderWithProviders(
+        <WireGuardDeviceList
+          devices={[createMockDevice()]}
+          deviceLimit={3}
+          onAddDevice={mockOnAddDevice}
+          onRedownloadConfig={mockOnRedownloadConfig}
+          onRegenerateAll={mockOnRegenerateAll}
+        />,
+      );
+
+      const regenerateButton = screen.getByText("Regenerate All Configs");
+      await user.click(regenerateButton);
+
+      expect(mockOnRegenerateAll).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("different device limits", () => {
+    it("should work correctly with device limit of 1", () => {
+      const devices = [createMockDevice()];
+
+      renderWithProviders(
+        <WireGuardDeviceList
+          devices={devices}
+          deviceLimit={1}
+          onAddDevice={mockOnAddDevice}
+          onRedownloadConfig={mockOnRedownloadConfig}
+          onRegenerateAll={mockOnRegenerateAll}
+        />,
+      );
+
+      expect(screen.getByText("Devices (1/1)")).toBeInTheDocument();
+      expect(screen.queryByText("+ Add Device")).not.toBeInTheDocument();
+      expect(screen.getByText(/Device limit reached/i)).toBeInTheDocument();
+    });
+
+    it("should work correctly with device limit of 5", () => {
+      const devices = [
+        createMockDevice(),
+        createMockDevice(),
+        createMockDevice(),
+      ];
+
+      renderWithProviders(
+        <WireGuardDeviceList
+          devices={devices}
+          deviceLimit={5}
+          onAddDevice={mockOnAddDevice}
+          onRedownloadConfig={mockOnRedownloadConfig}
+          onRegenerateAll={mockOnRegenerateAll}
+        />,
+      );
+
+      expect(screen.getByText("Devices (3/5)")).toBeInTheDocument();
+      expect(screen.getByText("+ Add Device")).toBeInTheDocument();
+      expect(screen.queryByText(/Device limit reached/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should render correctly with exactly one device", () => {
+      const device = createMockDevice({ name: "Single Device" });
+
+      renderWithProviders(
+        <WireGuardDeviceList
+          devices={[device]}
+          deviceLimit={3}
+          onAddDevice={mockOnAddDevice}
+          onRedownloadConfig={mockOnRedownloadConfig}
+          onRegenerateAll={mockOnRegenerateAll}
+        />,
+      );
+
+      expect(screen.getByText("Devices (1/3)")).toBeInTheDocument();
+      expect(screen.getByText("Single Device")).toBeInTheDocument();
+      expect(screen.getByText("+ Add Device")).toBeInTheDocument();
+      expect(screen.getByText("Regenerate All Configs")).toBeInTheDocument();
+    });
+
+    it("should handle device with empty name", () => {
+      const device = createMockDevice({ name: "" });
+
+      renderWithProviders(
+        <WireGuardDeviceList
+          devices={[device]}
+          deviceLimit={3}
+          onAddDevice={mockOnAddDevice}
+          onRedownloadConfig={mockOnRedownloadConfig}
+          onRegenerateAll={mockOnRegenerateAll}
+        />,
+      );
+
+      // Should still render without crashing
+      expect(screen.getByText("Devices (1/3)")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/pages/DocsFaqs.tsx
+++ b/src/pages/DocsFaqs.tsx
@@ -1,112 +1,351 @@
 import { Link } from "react-router";
-import { useState } from "react";
+import { useState, useMemo } from "react";
+import {
+  shouldShowWireGuardUI,
+  isOpenVpnAvailable,
+} from "../components/ProtocolToggle";
 
 interface FAQItem {
   id: string;
   question: string;
   answer: string;
+  /** Show only when WireGuard is enabled and OpenVPN is not available */
+  wireGuardOnly?: boolean;
+  /** Show only when OpenVPN is available and WireGuard is not enabled */
+  openVpnOnly?: boolean;
+  /** Show only when both protocols are available */
+  bothProtocols?: boolean;
 }
 
 const DocsFaqs = () => {
   const [openItems, setOpenItems] = useState<string[]>([]);
 
-  const faqs: FAQItem[] = [
-    {
-      id: "what-is-nabu",
-      question: "What is NABU VPN?",
-      answer:
-        "Nabu uses your Cardano wallet as your identity—no signup forms, no tracking cookies. Once connected, you're seconds away from spinning up a secure VPN tunnel that hides your IP, encrypts your traffic, and keeps your data yours.",
-    },
-    {
-      id: "how-does-it-work",
-      question: "How does NABU VPN work?",
-      answer:
-        "Simply connect your Cardano wallet, select a plan, download your profile and launch OpenVPN.",
-    },
-    {
-      id: "why-use-vpn",
-      question: "What is a VPN and why do people use them?",
-      answer:
-        "VPN stands for Virtual Private Network. A VPN has many benefits, for example a VPN can protect your privacy by encrypting your internet traffic and hiding your real IP address. It can also enhance security on public Wi-Fi and bypass geo-restrictions and government censorship to access blocked content. VPN can also be used to prevent your Internet Service Provider (ISP) from throttling your connection when visiting certain sites.",
-    },
-    {
-      id: "profile-download-time",
-      question:
-        "If I purchase a VPN plan, how long before I can download my profile?",
-      answer:
-        "It only takes a few seconds to a few minutes for the transaction to get on-chain and for your profile to be created. You can always check the status of your VPN instances on our site.",
-    },
-    {
-      id: "wallet-needed-per-device",
-      question:
-        "Will I need to connect my wallet on each device that I use OpenVPN on?",
-      answer:
-        "No, you just need your profile .ovpn file to import onto your device.",
-    },
-    {
-      id: "payments-accepted",
-      question: "Can I pay in another payment method besides ADA?",
-      answer:
-        "No, ADA (Cardano) is the only accepted payment method at this time.",
-    },
-    {
-      id: "multiple-devices-same-time",
-      question:
-        "Can I use the same VPN on more than one device at the same time?",
-      answer:
-        "No. Each profile is a single concurrent connection. You can purchase additional subscriptions if you need to support more than one device at the same time.",
-    },
-    {
-      id: "expire-notification",
-      question: "Will I get notified when my plan expires?",
-      answer:
-        "The whole point of a VPN is to protect your personal data. We do not ask for your contact information, so we have no way to notify you.",
-    },
-    {
-      id: "renew-plan-new-profile",
-      question: "Will I need to download a new profile when I renew my plan?",
-      answer:
-        "No, renewing your plan lets you keep enjoying your current profile.",
-    },
-    {
-      id: "switch-wallets",
-      question: "What if I switch wallets?",
-      answer:
-        "Your plan will continue to work but you won’t be able to renew your plan or redownload your profile. Plans are tied to your wallet address, and you must have access to the original wallet for any management actions.",
-    },
-    {
-      id: "use-other-devices",
-      question: "Can I use other devices with the OpenVPN protocol?",
-      answer:
-        "The VPN should be usable with any device that supports the OpenVPN client and importing an OVPN file to configure it. This includes common platforms such as Linux, Windows, macOS, iOS, and Android. See the OpenVPN Community page and open source repos here https://openvpn.net/community/",
-    },
-    {
-      id: "transaction-download-profile",
-      question:
-        "Why do I have to sign a message with my wallet to download my profile?",
-      answer:
-        "The message signing process verifies that your wallet is the owner of the specified profile. There are no transactions generated and therefore no transaction fees.",
-    },
-    {
-      id: "multiple-instances",
-      question: "Can I buy multiple VPN instances?",
-      answer:
-        "Yes, you can purchase multiple subscriptions that give you a different profile per instance.",
-    },
-    {
-      id: "ip-address-for-openvpn",
-      question: "Can NABU see the IP address that I use to connect to OpenVPN?",
-      answer:
-        "No, we purposely do not log this information for your privacy. To find out more about how NABU works, see our How it works page (https://nabuvpn.com/how-it-works)",
-    },
-    {
-      id: "wallet-balance-difference",
-      question:
-        "Why doesn't the wallet balance on the Account page match the balance shown by my wallet?",
-      answer:
-        "Many wallets will automatically include any unclaimed staking rewards when displaying the overall balance, but NABU is only querying the current wallet balance without unclaimed staking rewards. This may result in a small difference in the balance displayed, but it has no effect on your ability to manage your VPN subscriptions or the funds available in your wallet.",
-    },
-  ];
+  const wireGuardEnabled = shouldShowWireGuardUI();
+  const openVpnEnabled = isOpenVpnAvailable();
+  const bothEnabled = wireGuardEnabled && openVpnEnabled;
+
+  // Build FAQ list based on enabled protocols
+  const faqs: FAQItem[] = useMemo(() => {
+    const allFaqs: FAQItem[] = [
+      {
+        id: "what-is-nabu",
+        question: "What is NABU VPN?",
+        answer:
+          "Nabu uses your Cardano wallet as your identity—no signup forms, no tracking cookies. Once connected, you're seconds away from spinning up a secure VPN tunnel that hides your IP, encrypts your traffic, and keeps your data yours.",
+      },
+      // Protocol-specific "How does it work" answers
+      {
+        id: "how-does-it-work-both",
+        question: "How does NABU VPN work?",
+        answer:
+          "Simply connect your Cardano wallet, select a plan, and configure your devices. For WireGuard, you can register up to 3 devices per subscription. For OpenVPN, download your profile and import it into your OpenVPN client.",
+        bothProtocols: true,
+      },
+      {
+        id: "how-does-it-work-wg",
+        question: "How does NABU VPN work?",
+        answer:
+          "Simply connect your Cardano wallet, select a plan, and configure your devices. Each WireGuard subscription supports up to 3 devices—add them through the web interface and download the configuration to import into your WireGuard client.",
+        wireGuardOnly: true,
+      },
+      {
+        id: "how-does-it-work-ovpn",
+        question: "How does NABU VPN work?",
+        answer:
+          "Simply connect your Cardano wallet, select a plan, and download your profile. Import the .ovpn file into your OpenVPN client and connect. Your profile stays valid until your subscription expires.",
+        openVpnOnly: true,
+      },
+      // WireGuard-specific FAQs (show whenever WireGuard is enabled)
+      {
+        id: "why-wireguard-both",
+        question: "Why WireGuard?",
+        answer:
+          "WireGuard is a modern VPN protocol designed for simplicity, speed, and security. It uses state-of-the-art cryptography and has a much smaller codebase than older protocols, making it easier to audit and less prone to vulnerabilities. WireGuard typically provides faster connection times and better performance, especially on mobile devices where it excels at handling network changes seamlessly.",
+        bothProtocols: true,
+      },
+      {
+        id: "why-wireguard-wg",
+        question: "Why WireGuard?",
+        answer:
+          "WireGuard is a modern VPN protocol designed for simplicity, speed, and security. It uses state-of-the-art cryptography and has a much smaller codebase than older protocols, making it easier to audit and less prone to vulnerabilities. WireGuard typically provides faster connection times and better performance, especially on mobile devices where it excels at handling network changes seamlessly.",
+        wireGuardOnly: true,
+      },
+      // Comparison FAQ (only when both available)
+      {
+        id: "wireguard-vs-openvpn",
+        question: "WireGuard vs OpenVPN",
+        answer:
+          "WireGuard is newer, faster, and more efficient. It establishes connections almost instantly versus several seconds for OpenVPN. WireGuard uses modern cryptographic primitives (ChaCha20, Curve25519, BLAKE2) while OpenVPN relies on OpenSSL. WireGuard's codebase is around 4,000 lines compared to OpenVPN's 100,000+, making it easier to audit. However, OpenVPN has been around longer and is supported on more devices and platforms. Both protocols are secure when properly configured.",
+        bothProtocols: true,
+      },
+      {
+        id: "openvpn-compatibility",
+        question: "When should I use OpenVPN?",
+        answer:
+          "OpenVPN is provided for compatibility with devices and systems that don't yet support WireGuard. You might choose OpenVPN if:\n\n• Your device or router only supports OpenVPN\n• You're using an older operating system without WireGuard support\n• Your network administrator requires OpenVPN\n• You need to use TCP mode to bypass restrictive firewalls (WireGuard is UDP-only)\n\nFor most users on modern devices, we recommend WireGuard for its superior performance.",
+        bothProtocols: true,
+      },
+      // OpenVPN-specific FAQs (show whenever OpenVPN is available)
+      {
+        id: "about-openvpn-both",
+        question: "About OpenVPN",
+        answer:
+          "OpenVPN is a mature, widely-supported VPN protocol that has been around since 2001. It uses OpenSSL for encryption and works on virtually every platform. OpenVPN can operate over both TCP and UDP, making it useful for bypassing restrictive firewalls. While newer protocols may offer better performance, OpenVPN remains a reliable and secure choice.",
+        bothProtocols: true,
+      },
+      {
+        id: "about-openvpn-ovpn",
+        question: "About OpenVPN",
+        answer:
+          "OpenVPN is a mature, widely-supported VPN protocol that has been around since 2001. It uses OpenSSL for encryption and works on virtually every platform. OpenVPN can operate over both TCP and UDP, making it useful for bypassing restrictive firewalls. While newer protocols may offer better performance, OpenVPN remains a reliable and secure choice.",
+        openVpnOnly: true,
+      },
+      {
+        id: "why-use-vpn",
+        question: "What is a VPN and why do people use them?",
+        answer:
+          "VPN stands for Virtual Private Network. A VPN has many benefits, for example a VPN can protect your privacy by encrypting your internet traffic and hiding your real IP address. It can also enhance security on public Wi-Fi and bypass geo-restrictions and government censorship to access blocked content. VPN can also be used to prevent your Internet Service Provider (ISP) from throttling your connection when visiting certain sites.",
+      },
+      // Setup time - protocol aware
+      {
+        id: "setup-time-both",
+        question: "How long after purchase can I start using the VPN?",
+        answer:
+          "It only takes a few seconds to a few minutes for your transaction to be confirmed on-chain. For WireGuard, you can add devices immediately once your subscription is active—device registration happens instantly. For OpenVPN, your profile is generated within moments. You can check your subscription status anytime on the Account page.",
+        bothProtocols: true,
+      },
+      {
+        id: "setup-time-wg",
+        question: "How long after purchase can I start using the VPN?",
+        answer:
+          "It only takes a few seconds to a few minutes for your transaction to be confirmed on-chain. Once your subscription is active, you can add devices immediately—registration happens instantly. You can check your subscription status anytime on the Account page.",
+        wireGuardOnly: true,
+      },
+      {
+        id: "setup-time-ovpn",
+        question: "How long after purchase can I start using the VPN?",
+        answer:
+          "It only takes a few seconds to a few minutes for your transaction to be confirmed on-chain. Your OpenVPN profile is generated within moments after confirmation. You can check your subscription status anytime on the Account page.",
+        openVpnOnly: true,
+      },
+      // Wallet per device - protocol aware
+      {
+        id: "wallet-needed-per-device-both",
+        question: "Will I need to connect my wallet on each device?",
+        answer:
+          "For WireGuard, you'll need your wallet connected when adding new devices through the web interface—this is where your device keys are registered. Once configured, your devices connect directly to the VPN without needing wallet access. For OpenVPN, you just need your .ovpn profile file to import onto your device.",
+        bothProtocols: true,
+      },
+      {
+        id: "wallet-needed-per-device-wg",
+        question: "Will I need to connect my wallet on each device?",
+        answer:
+          "You'll need your wallet connected when adding new devices through the web interface—this is where your device keys are registered. Once configured, your devices connect directly to the VPN without needing wallet access.",
+        wireGuardOnly: true,
+      },
+      {
+        id: "wallet-needed-per-device-ovpn",
+        question: "Will I need to connect my wallet on each device?",
+        answer:
+          "No, you just need your .ovpn profile file to import onto your device. You only need your wallet connected to download or re-download your profile.",
+        openVpnOnly: true,
+      },
+      {
+        id: "payments-accepted",
+        question: "Can I pay in another payment method besides ADA?",
+        answer:
+          "No, ADA (Cardano) is the only accepted payment method at this time.",
+      },
+      // Multiple devices - protocol aware
+      {
+        id: "multiple-devices-same-time-both",
+        question: "Can I use the same VPN subscription on multiple devices?",
+        answer:
+          "With WireGuard, yes! Each subscription supports up to 3 devices, so you can connect from your phone, laptop, and desktop simultaneously. With OpenVPN, each subscription supports one device at a time. If you need more concurrent connections, you can purchase additional subscriptions.",
+        bothProtocols: true,
+      },
+      {
+        id: "multiple-devices-same-time-wg",
+        question: "Can I use the same VPN subscription on multiple devices?",
+        answer:
+          "Yes! Each subscription supports up to 3 devices, so you can connect from your phone, laptop, and desktop simultaneously. If you need more than 3 concurrent connections, you can purchase additional subscriptions.",
+        wireGuardOnly: true,
+      },
+      {
+        id: "multiple-devices-same-time-ovpn",
+        question: "Can I use the same VPN subscription on multiple devices?",
+        answer:
+          "Each OpenVPN subscription supports one concurrent connection. You can install your profile on multiple devices, but only one can be connected at a time. If you need simultaneous connections, you can purchase additional subscriptions.",
+        openVpnOnly: true,
+      },
+      {
+        id: "expire-notification",
+        question: "Will I get notified when my plan expires?",
+        answer:
+          "The whole point of a VPN is to protect your personal data. We do not ask for your contact information, so we have no way to notify you.",
+      },
+      // Renew - protocol aware
+      {
+        id: "renew-plan-new-profile-both",
+        question: "Will I need to reconfigure my devices when I renew my plan?",
+        answer:
+          "No, renewing your plan extends your existing subscription. Your WireGuard devices and OpenVPN profiles continue working without any reconfiguration.",
+        bothProtocols: true,
+      },
+      {
+        id: "renew-plan-new-profile-wg",
+        question: "Will I need to reconfigure my devices when I renew my plan?",
+        answer:
+          "No, renewing your plan extends your existing subscription. Your device configurations continue working without any changes.",
+        wireGuardOnly: true,
+      },
+      {
+        id: "renew-plan-new-profile-ovpn",
+        question: "Will I need to download a new profile when I renew my plan?",
+        answer:
+          "No, renewing your plan extends your existing subscription. Your profile continues working without any changes.",
+        openVpnOnly: true,
+      },
+      // Switch wallets - protocol aware
+      {
+        id: "switch-wallets-both",
+        question: "What if I switch wallets?",
+        answer:
+          "Your existing VPN connections will continue to work, but you won't be able to renew your subscription, add new WireGuard devices, re-download OpenVPN profiles, or manage your account. Subscriptions are tied to your wallet address, and you must have access to the original wallet for any management actions.",
+        bothProtocols: true,
+      },
+      {
+        id: "switch-wallets-wg",
+        question: "What if I switch wallets?",
+        answer:
+          "Your existing VPN connections will continue to work, but you won't be able to renew your subscription, add new WireGuard devices, or manage your account. Subscriptions are tied to your wallet address, and you must have access to the original wallet for any management actions.",
+        wireGuardOnly: true,
+      },
+      {
+        id: "switch-wallets-ovpn",
+        question: "What if I switch wallets?",
+        answer:
+          "Your existing VPN connections will continue to work, but you won't be able to renew your subscription or re-download your profile. Subscriptions are tied to your wallet address, and you must have access to the original wallet for any management actions.",
+        openVpnOnly: true,
+      },
+      // Supported devices - protocol aware
+      {
+        id: "supported-devices-both",
+        question: "What devices are supported?",
+        answer:
+          "WireGuard is supported on all major platforms including Windows, macOS, Linux, iOS, and Android. Most modern devices and operating systems have native WireGuard support or official apps available. For older devices that don't support WireGuard, OpenVPN is available as a fallback option with clients for virtually every platform. See wireguard.com/install and openvpn.net/community for client downloads.",
+        bothProtocols: true,
+      },
+      {
+        id: "supported-devices-wg",
+        question: "What devices are supported?",
+        answer:
+          "WireGuard is supported on all major platforms including Windows, macOS, Linux, iOS, and Android. Most modern devices and operating systems have native WireGuard support or official apps available. See wireguard.com/install for client downloads.",
+        wireGuardOnly: true,
+      },
+      {
+        id: "supported-devices-ovpn",
+        question: "What devices are supported?",
+        answer:
+          "OpenVPN is supported on virtually every platform including Windows, macOS, Linux, iOS, Android, and many routers. See openvpn.net/community for client downloads.",
+        openVpnOnly: true,
+      },
+      // Wallet signing - protocol aware
+      {
+        id: "wallet-signing-both",
+        question: "Why do I have to sign a message with my wallet?",
+        answer:
+          "Message signing verifies that you own the wallet associated with your subscription. For WireGuard, signing authorizes device registration. For OpenVPN, it authenticates profile downloads. This is just a cryptographic signature—no transaction is created and there are no fees.",
+        bothProtocols: true,
+      },
+      {
+        id: "wallet-signing-wg",
+        question: "Why do I have to sign a message with my wallet?",
+        answer:
+          "Message signing verifies that you own the wallet associated with your subscription. Signing authorizes device registration. This is just a cryptographic signature—no transaction is created and there are no fees.",
+        wireGuardOnly: true,
+      },
+      {
+        id: "wallet-signing-ovpn",
+        question: "Why do I have to sign a message with my wallet to download my profile?",
+        answer:
+          "The message signing process verifies that your wallet is the owner of the specified subscription. There are no transactions generated and therefore no transaction fees.",
+        openVpnOnly: true,
+      },
+      // Multiple instances - protocol aware
+      {
+        id: "multiple-instances-both",
+        question: "Can I buy multiple VPN subscriptions?",
+        answer:
+          "Yes, you can purchase multiple subscriptions. Each WireGuard subscription supports up to 3 devices, and you can have subscriptions in different regions. This is useful if you need more than 3 simultaneous connections or want to access content from multiple geographic locations.",
+        bothProtocols: true,
+      },
+      {
+        id: "multiple-instances-wg",
+        question: "Can I buy multiple VPN subscriptions?",
+        answer:
+          "Yes, you can purchase multiple subscriptions. Each WireGuard subscription supports up to 3 devices, and you can have subscriptions in different regions. This is useful if you need more than 3 simultaneous connections or want to access content from multiple geographic locations.",
+        wireGuardOnly: true,
+      },
+      {
+        id: "multiple-instances-ovpn",
+        question: "Can I buy multiple VPN subscriptions?",
+        answer:
+          "Yes, you can purchase multiple subscriptions for different regions or to support more concurrent connections.",
+        openVpnOnly: true,
+      },
+      // IP logging - protocol aware
+      {
+        id: "ip-address-logging-both",
+        question: "Can NABU see my IP address when I connect to the VPN?",
+        answer:
+          "No, we purposely disable all logging on our VPN servers for your privacy. This applies to both WireGuard and OpenVPN connections. To learn more about our privacy-focused architecture, see our How it works page.",
+        bothProtocols: true,
+      },
+      {
+        id: "ip-address-logging-wg",
+        question: "Can NABU see my IP address when I connect to the VPN?",
+        answer:
+          "No, we purposely disable all logging on our VPN servers for your privacy. To learn more about our privacy-focused architecture, see our How it works page.",
+        wireGuardOnly: true,
+      },
+      {
+        id: "ip-address-logging-ovpn",
+        question: "Can NABU see the IP address that I use to connect to OpenVPN?",
+        answer:
+          "No, we purposely do not log this information for your privacy. To learn more about our privacy-focused architecture, see our How it works page.",
+        openVpnOnly: true,
+      },
+      {
+        id: "wallet-balance-difference",
+        question:
+          "Why doesn't the wallet balance on the Account page match the balance shown by my wallet?",
+        answer:
+          "Many wallets will automatically include any unclaimed staking rewards when displaying the overall balance, but NABU is only querying the current wallet balance without unclaimed staking rewards. This may result in a small difference in the balance displayed, but it has no effect on your ability to manage your VPN subscriptions or the funds available in your wallet.",
+      },
+    ];
+
+    // Filter FAQs based on enabled protocols
+    return allFaqs.filter((faq) => {
+      // Show if no protocol restriction
+      if (!faq.wireGuardOnly && !faq.openVpnOnly && !faq.bothProtocols) {
+        return true;
+      }
+      // Both protocols required
+      if (faq.bothProtocols) {
+        return bothEnabled;
+      }
+      // WireGuard only (show when WG enabled and OpenVPN not available, or explicitly WG-only)
+      if (faq.wireGuardOnly) {
+        return wireGuardEnabled && !openVpnEnabled;
+      }
+      // OpenVPN only (show when OpenVPN available and WireGuard not enabled)
+      if (faq.openVpnOnly) {
+        return openVpnEnabled && !wireGuardEnabled;
+      }
+      return true;
+    });
+  }, [wireGuardEnabled, openVpnEnabled, bothEnabled]);
 
   const toggleItem = (id: string) => {
     setOpenItems((prev) =>

--- a/src/pages/InstallGuide.tsx
+++ b/src/pages/InstallGuide.tsx
@@ -1,44 +1,791 @@
+import { useState } from "react";
 import { Link } from "react-router";
+import { detectDeviceTypeRaw } from "../utils/deviceDetection";
+import type { DeviceType } from "../utils/deviceDetection";
+import {
+  shouldShowWireGuardUI,
+  isOpenVpnAvailable,
+} from "../components/ProtocolToggle";
 
-const InstallGuide = () => {
+// Check protocol availability using shared helpers
+const isWireGuardEnabled = shouldShowWireGuardUI();
+const isOpenVpnEnabled = isOpenVpnAvailable();
+
+/**
+ * Get platform-specific WireGuard installation info
+ */
+function getWireGuardInstallInfo(deviceType: DeviceType): {
+  appName: string;
+  downloadUrl: string;
+  storeText: string;
+  instructions: string[];
+} {
+  switch (deviceType) {
+    case "windows":
+      return {
+        appName: "WireGuard for Windows",
+        downloadUrl: "https://www.wireguard.com/install/",
+        storeText: "Download from wireguard.com",
+        instructions: [
+          "Download the WireGuard installer from the official website",
+          "Run the installer and follow the prompts",
+          "Once installed, WireGuard will appear in your system tray",
+        ],
+      };
+    case "mac":
+      return {
+        appName: "WireGuard for macOS",
+        downloadUrl: "https://apps.apple.com/app/wireguard/id1451685025",
+        storeText: "Download from App Store",
+        instructions: [
+          "Download WireGuard from the Mac App Store",
+          "Open the app and grant the necessary permissions",
+          "WireGuard will appear in your menu bar",
+        ],
+      };
+    case "iphone":
+    case "ipad":
+      return {
+        appName: "WireGuard for iOS",
+        downloadUrl: "https://apps.apple.com/app/wireguard/id1441195209",
+        storeText: "Download from App Store",
+        instructions: [
+          "Download WireGuard from the App Store",
+          "Open the app and tap 'Add a tunnel'",
+          "Choose 'Create from QR code' to scan your config",
+        ],
+      };
+    case "android":
+      return {
+        appName: "WireGuard for Android",
+        downloadUrl: "https://play.google.com/store/apps/details?id=com.wireguard.android",
+        storeText: "Download from Play Store",
+        instructions: [
+          "Download WireGuard from the Play Store",
+          "Open the app and tap the '+' button",
+          "Choose 'Scan from QR code' to scan your config",
+        ],
+      };
+    case "linux":
+      return {
+        appName: "WireGuard for Linux",
+        downloadUrl: "https://www.wireguard.com/install/",
+        storeText: "Install via package manager",
+        instructions: [
+          "Install using your distribution's package manager (see commands below)",
+          "Import your configuration file to /etc/wireguard/",
+          "Use 'wg-quick up' to connect",
+        ],
+      };
+    default:
+      return {
+        appName: "WireGuard",
+        downloadUrl: "https://www.wireguard.com/install/",
+        storeText: "Visit wireguard.com",
+        instructions: [
+          "Download WireGuard for your platform from wireguard.com",
+          "Install and open the application",
+          "Import your configuration file or scan the QR code",
+        ],
+      };
+  }
+}
+
+/**
+ * Get the human-readable device name for display
+ */
+function getDeviceDisplayName(deviceType: DeviceType): string {
+  switch (deviceType) {
+    case "windows":
+      return "Windows";
+    case "mac":
+      return "macOS";
+    case "iphone":
+      return "iPhone";
+    case "ipad":
+      return "iPad";
+    case "android":
+      return "Android";
+    case "linux":
+      return "Linux";
+    default:
+      return "your device";
+  }
+}
+
+/**
+ * Platform icon component
+ */
+const PlatformIcon = ({ deviceType, className = "w-8 h-8" }: { deviceType: DeviceType; className?: string }) => {
+  switch (deviceType) {
+    case "windows":
+      return (
+        <svg className={`${className} text-blue-400`} viewBox="0 0 24 24" fill="currentColor">
+          <path d="M3 12V6.75l6-1.32v6.48L3 12zm17-9v8.75l-10 .15V5.21L20 3zM3 13l6 .09v6.81l-6-1.15V13zm17 .25V22l-10-1.91v-6.75l10 .15z" />
+        </svg>
+      );
+    case "mac":
+      return (
+        <svg className={`${className} text-gray-300`} viewBox="0 0 24 24" fill="currentColor">
+          <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
+        </svg>
+      );
+    case "iphone":
+    case "ipad":
+    case "android":
+      return (
+        <svg className={`${className} text-green-400`} viewBox="0 0 24 24" fill="currentColor">
+          <path d="M17 1.01L7 1c-1.1 0-1.99.9-1.99 2v18c0 1.1.89 2 2 2h10c1.1 0 2-.9 2-2V3c0-1.1-.9-1.99-2-1.99zM17 19H7V5h10v14z" />
+        </svg>
+      );
+    case "linux":
+      return (
+        <svg className={`${className} text-orange-400`} viewBox="0 0 24 24" fill="currentColor">
+          <path d="M12.504 0C5.588 0 0 5.588 0 12.504s5.588 12.504 12.504 12.504S25.008 19.42 25.008 12.504 19.42 0 12.504 0zm0 22.008c-5.243 0-9.504-4.261-9.504-9.504S7.261 3 12.504 3s9.504 4.261 9.504 9.504-4.261 9.504-9.504 9.504z" />
+        </svg>
+      );
+    default:
+      return (
+        <svg className={`${className} text-purple-400`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+        </svg>
+      );
+  }
+};
+
+/**
+ * Collapsible section component
+ */
+const CollapsibleSection = ({
+  title,
+  children,
+  defaultOpen = false,
+}: {
+  title: string;
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+}) => {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+
   return (
-    <div className="flex flex-col relative pt-16 min-h-screen overflow-hidden">
-      <div className="max-w-4xl mx-auto px-6 py-12 relative z-10">
-        <div className="text-center mb-12">
-          <h1 className="text-5xl font-bold bg-gradient-to-r from-white via-blue-200 to-purple-200 bg-clip-text text-transparent mb-4">
-            How to Install NABU VPN
-          </h1>
-          <p className="text-gray-300 text-lg mb-8">
-            Follow these steps to install OpenVPN and connect with your NABU
-            profile on any device.
-          </p>
+    <div className="bg-white/5 rounded-xl border border-white/10">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="w-full flex items-center justify-between p-4 text-left cursor-pointer hover:bg-white/5 transition-colors rounded-xl"
+        aria-expanded={isOpen}
+      >
+        <span className="text-lg font-semibold text-white">{title}</span>
+        <svg
+          className={`w-5 h-5 text-gray-400 transition-transform ${isOpen ? "rotate-180" : ""}`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      {isOpen && <div className="px-4 pb-4">{children}</div>}
+    </div>
+  );
+};
 
-          <div className="flex flex-col sm:flex-row items-center justify-center gap-8 mb-8">
-            <div className="flex items-center gap-3">
-              <div className="w-8 h-8 bg-white rounded-full flex items-center justify-center">
-                <span className="text-black font-bold text-sm">1</span>
-              </div>
-              <span className="text-white font-medium">Install OpenVPN</span>
-            </div>
-            <div className="flex items-center gap-3">
-              <div className="w-8 h-8 bg-white rounded-full flex items-center justify-center">
-                <span className="text-black font-bold text-sm">2</span>
-              </div>
-              <span className="text-white font-medium">Download Profile</span>
-            </div>
-            <div className="flex items-center gap-3">
-              <div className="w-8 h-8 bg-white rounded-full flex items-center justify-center">
-                <span className="text-black font-bold text-sm">3</span>
-              </div>
-              <span className="text-white font-medium">
-                Configure & Connect
-              </span>
-            </div>
+/**
+ * WireGuard Install Guide content
+ */
+const WireGuardInstallGuide = () => {
+  const deviceType = detectDeviceTypeRaw();
+  const deviceName = getDeviceDisplayName(deviceType);
+  const installInfo = getWireGuardInstallInfo(deviceType);
+  const isMobile = deviceType === "iphone" || deviceType === "ipad" || deviceType === "android";
+
+  return (
+    <>
+      {/* Platform detection banner */}
+      <div className="bg-gradient-to-r from-blue-500/20 to-purple-500/20 rounded-xl p-4 border border-blue-500/30 mb-8">
+        <div className="flex items-center gap-3">
+          <PlatformIcon deviceType={deviceType} className="w-10 h-10" />
+          <div>
+            <p className="text-white font-medium">
+              We detected you're on <span className="text-blue-400">{deviceName}</span>
+            </p>
+            <p className="text-gray-300 text-sm">Here's how to get started with NABU VPN</p>
           </div>
         </div>
+      </div>
 
-        <div className="bg-gradient-to-br from-[#00000066] to-[#1a1a2e66] rounded-2xl p-8 backdrop-blur-xl border border-[#ffffff2a] shadow-2xl">
-          <div className="space-y-8 mb-12">
+      {/* Quick steps overview */}
+      <div className="flex flex-col sm:flex-row items-center justify-center gap-8 mb-8">
+        <div className="flex items-center gap-3">
+          <div className="w-8 h-8 bg-white rounded-full flex items-center justify-center">
+            <span className="text-black font-bold text-sm">1</span>
+          </div>
+          <span className="text-white font-medium">Install WireGuard</span>
+        </div>
+        <div className="flex items-center gap-3">
+          <div className="w-8 h-8 bg-white rounded-full flex items-center justify-center">
+            <span className="text-black font-bold text-sm">2</span>
+          </div>
+          <span className="text-white font-medium">Get Your Config</span>
+        </div>
+        <div className="flex items-center gap-3">
+          <div className="w-8 h-8 bg-white rounded-full flex items-center justify-center">
+            <span className="text-black font-bold text-sm">3</span>
+          </div>
+          <span className="text-white font-medium">Import & Connect</span>
+        </div>
+      </div>
+
+      <div className="bg-gradient-to-br from-[#00000066] to-[#1a1a2e66] rounded-2xl p-8 backdrop-blur-xl border border-[#ffffff2a] shadow-2xl">
+        <div className="space-y-8">
+          {/* Step 1: Install WireGuard */}
+          <div className="bg-white/10 rounded-2xl p-8 backdrop-blur-xl border border-white/20">
+            <div className="flex items-center gap-4 mb-6">
+              <div className="w-12 h-12 bg-white rounded-full flex items-center justify-center">
+                <span className="text-black font-bold text-lg">1</span>
+              </div>
+              <h2 className="text-2xl font-bold text-white">Install WireGuard</h2>
+            </div>
+
+            {/* Recommended for detected platform */}
+            <div className="bg-blue-500/10 rounded-xl p-6 border border-blue-500/30 mb-6">
+              <div className="flex items-center gap-3 mb-4">
+                <PlatformIcon deviceType={deviceType} />
+                <div>
+                  <h3 className="text-lg font-semibold text-white">
+                    Recommended for {deviceName}
+                  </h3>
+                  <p className="text-gray-300 text-sm">{installInfo.appName}</p>
+                </div>
+              </div>
+              <a
+                href={installInfo.downloadUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 px-4 py-2 bg-blue-500 text-white font-semibold rounded-lg hover:bg-blue-600 transition-colors mb-4"
+              >
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                </svg>
+                {installInfo.storeText}
+              </a>
+              <ul className="space-y-2">
+                {installInfo.instructions.map((instruction, index) => (
+                  <li key={index} className="flex items-start gap-2 text-gray-300 text-sm">
+                    <span className="text-blue-400 mt-1">*</span>
+                    {instruction}
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            {/* Linux terminal commands */}
+            {deviceType === "linux" && (
+              <div className="space-y-3 mb-6">
+                <h4 className="text-white font-medium">Terminal Commands:</h4>
+                <div className="bg-white/5 rounded-lg p-3 border border-white/10">
+                  <div className="flex items-center gap-2 mb-2">
+                    <span className="text-green-400 text-sm font-mono">Ubuntu/Debian:</span>
+                  </div>
+                  <code className="text-green-400 font-mono text-sm">
+                    sudo apt install wireguard
+                  </code>
+                </div>
+                <div className="bg-white/5 rounded-lg p-3 border border-white/10">
+                  <div className="flex items-center gap-2 mb-2">
+                    <span className="text-green-400 text-sm font-mono">Fedora:</span>
+                  </div>
+                  <code className="text-green-400 font-mono text-sm">
+                    sudo dnf install wireguard-tools
+                  </code>
+                </div>
+                <div className="bg-white/5 rounded-lg p-3 border border-white/10">
+                  <div className="flex items-center gap-2 mb-2">
+                    <span className="text-green-400 text-sm font-mono">Arch Linux:</span>
+                  </div>
+                  <code className="text-green-400 font-mono text-sm">
+                    sudo pacman -S wireguard-tools
+                  </code>
+                </div>
+              </div>
+            )}
+
+            {/* Other platforms */}
+            <CollapsibleSection title="Other Platforms">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-4">
+                {deviceType !== "windows" && (
+                  <div className="bg-white/5 rounded-xl p-4 border border-white/10">
+                    <div className="flex items-center gap-3 mb-3">
+                      <PlatformIcon deviceType="windows" className="w-6 h-6" />
+                      <h4 className="text-white font-medium">Windows</h4>
+                    </div>
+                    <a
+                      href="https://www.wireguard.com/install/"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-400 hover:text-white transition-colors text-sm"
+                    >
+                      Download from wireguard.com
+                    </a>
+                  </div>
+                )}
+                {deviceType !== "mac" && (
+                  <div className="bg-white/5 rounded-xl p-4 border border-white/10">
+                    <div className="flex items-center gap-3 mb-3">
+                      <PlatformIcon deviceType="mac" className="w-6 h-6" />
+                      <h4 className="text-white font-medium">macOS</h4>
+                    </div>
+                    <a
+                      href="https://apps.apple.com/app/wireguard/id1451685025"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-400 hover:text-white transition-colors text-sm"
+                    >
+                      Download from App Store
+                    </a>
+                  </div>
+                )}
+                {deviceType !== "iphone" && deviceType !== "ipad" && (
+                  <div className="bg-white/5 rounded-xl p-4 border border-white/10">
+                    <div className="flex items-center gap-3 mb-3">
+                      <PlatformIcon deviceType="iphone" className="w-6 h-6" />
+                      <h4 className="text-white font-medium">iOS (iPhone/iPad)</h4>
+                    </div>
+                    <a
+                      href="https://apps.apple.com/app/wireguard/id1441195209"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-400 hover:text-white transition-colors text-sm"
+                    >
+                      Download from App Store
+                    </a>
+                  </div>
+                )}
+                {deviceType !== "android" && (
+                  <div className="bg-white/5 rounded-xl p-4 border border-white/10">
+                    <div className="flex items-center gap-3 mb-3">
+                      <PlatformIcon deviceType="android" className="w-6 h-6" />
+                      <h4 className="text-white font-medium">Android</h4>
+                    </div>
+                    <a
+                      href="https://play.google.com/store/apps/details?id=com.wireguard.android"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-400 hover:text-white transition-colors text-sm"
+                    >
+                      Download from Play Store
+                    </a>
+                  </div>
+                )}
+                {deviceType !== "linux" && (
+                  <div className="bg-white/5 rounded-xl p-4 border border-white/10">
+                    <div className="flex items-center gap-3 mb-3">
+                      <PlatformIcon deviceType="linux" className="w-6 h-6" />
+                      <h4 className="text-white font-medium">Linux</h4>
+                    </div>
+                    <p className="text-gray-300 text-sm">
+                      Install via package manager (apt, dnf, pacman)
+                    </p>
+                  </div>
+                )}
+              </div>
+            </CollapsibleSection>
+          </div>
+
+          {/* Step 2: Get Your Config */}
+          <div className="bg-white/10 rounded-2xl p-8 backdrop-blur-xl border border-white/20">
+            <div className="flex items-center gap-4 mb-6">
+              <div className="w-12 h-12 bg-white rounded-full flex items-center justify-center">
+                <span className="text-black font-bold text-lg">2</span>
+              </div>
+              <h2 className="text-2xl font-bold text-white">Get Your Config</h2>
+            </div>
+
+            <div className="bg-white/5 rounded-xl p-6 border border-white/10">
+              <div className="flex items-center gap-3 mb-4">
+                <svg className="w-8 h-8 text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+                </svg>
+                <h3 className="text-lg font-semibold text-white">Connect Wallet & Add Device</h3>
+              </div>
+              <p className="text-gray-300 mb-4">
+                Go to your account page, connect your Cardano wallet, and purchase a VPN subscription.
+                Then add a device to get your WireGuard configuration.
+              </p>
+              <Link
+                to="/account"
+                className="inline-flex items-center gap-2 px-6 py-3 bg-white text-black font-semibold rounded-lg hover:bg-gray-100 transition-all duration-200"
+              >
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
+                </svg>
+                Go to Account Page
+              </Link>
+            </div>
+          </div>
+
+          {/* Step 3: Import Config */}
+          <div className="bg-white/10 rounded-2xl p-8 backdrop-blur-xl border border-white/20">
+            <div className="flex items-center gap-4 mb-6">
+              <div className="w-12 h-12 bg-white rounded-full flex items-center justify-center">
+                <span className="text-black font-bold text-lg">3</span>
+              </div>
+              <h2 className="text-2xl font-bold text-white">Import & Connect</h2>
+            </div>
+
+            {/* QR Code section for mobile */}
+            {isMobile && (
+              <div className="bg-purple-500/10 rounded-xl p-6 border border-purple-500/30 mb-6">
+                <div className="flex items-center gap-3 mb-4">
+                  <svg className="w-8 h-8 text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v1m6 11h2m-6 0h-2v4m0-11v3m0 0h.01M12 12h4.01M16 20h4M4 12h4m12 0h.01M5 8h2a1 1 0 001-1V5a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1zm12 0h2a1 1 0 001-1V5a1 1 0 00-1-1h-2a1 1 0 00-1 1v2a1 1 0 001 1zM5 20h2a1 1 0 001-1v-2a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1z" />
+                  </svg>
+                  <h3 className="text-lg font-semibold text-white">Scan QR Code (Easiest Method)</h3>
+                </div>
+                <p className="text-gray-300 mb-4">
+                  The easiest way to import your WireGuard configuration on mobile is to scan the QR code:
+                </p>
+                <ol className="space-y-2 text-gray-300 text-sm">
+                  <li className="flex items-start gap-2">
+                    <span className="text-purple-400 font-bold">1.</span>
+                    Open the WireGuard app on your {deviceName}
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="text-purple-400 font-bold">2.</span>
+                    Tap the "+" button to add a new tunnel
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="text-purple-400 font-bold">3.</span>
+                    Select "Create from QR code" or "Scan from QR code"
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="text-purple-400 font-bold">4.</span>
+                    Point your camera at the QR code shown on your Account page
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="text-purple-400 font-bold">5.</span>
+                    Give the tunnel a name and tap "Create Tunnel"
+                  </li>
+                </ol>
+              </div>
+            )}
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+              {/* Desktop/File Import */}
+              <div className="bg-white/5 rounded-xl p-6 border border-white/10">
+                <div className="flex items-center gap-3 mb-4">
+                  <svg className="w-8 h-8 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                  </svg>
+                  <h3 className="text-lg font-semibold text-white">Import Config File</h3>
+                </div>
+                <div className="space-y-3">
+                  <div className="bg-white/5 rounded-lg p-3 border border-white/10">
+                    <div className="flex items-center gap-2 mb-2">
+                      <PlatformIcon deviceType="windows" className="w-4 h-4" />
+                      <span className="text-gray-300 text-sm">Windows</span>
+                    </div>
+                    <span className="text-gray-300 text-sm">
+                      Click "Import tunnel(s) from file" and select your .conf file
+                    </span>
+                  </div>
+                  <div className="bg-white/5 rounded-lg p-3 border border-white/10">
+                    <div className="flex items-center gap-2 mb-2">
+                      <PlatformIcon deviceType="mac" className="w-4 h-4" />
+                      <span className="text-gray-300 text-sm">macOS</span>
+                    </div>
+                    <span className="text-gray-300 text-sm">
+                      Click "Import Tunnel(s) from File" or drag-and-drop the .conf file
+                    </span>
+                  </div>
+                  <div className="bg-white/5 rounded-lg p-3 border border-white/10">
+                    <div className="flex items-center gap-2 mb-2">
+                      <PlatformIcon deviceType="linux" className="w-4 h-4" />
+                      <span className="text-gray-300 text-sm">Linux</span>
+                    </div>
+                    <code className="text-green-400 font-mono text-sm">
+                      sudo wg-quick up ./nabu-wg.conf
+                    </code>
+                  </div>
+                </div>
+              </div>
+
+              {/* Connecting */}
+              <div className="bg-white/5 rounded-xl p-6 border border-white/10">
+                <div className="flex items-center gap-3 mb-4">
+                  <svg className="w-8 h-8 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+                  </svg>
+                  <h3 className="text-lg font-semibold text-white">Connect</h3>
+                </div>
+                <div className="space-y-3">
+                  <div className="bg-white/5 rounded-lg p-3 border border-white/10">
+                    <div className="flex items-center gap-2 mb-2">
+                      <PlatformIcon deviceType="windows" className="w-4 h-4" />
+                      <span className="text-gray-300 text-sm">Windows</span>
+                    </div>
+                    <span className="text-gray-300 text-sm">
+                      Click "Activate" on your tunnel
+                    </span>
+                  </div>
+                  <div className="bg-white/5 rounded-lg p-3 border border-white/10">
+                    <div className="flex items-center gap-2 mb-2">
+                      <PlatformIcon deviceType="mac" className="w-4 h-4" />
+                      <span className="text-gray-300 text-sm">macOS</span>
+                    </div>
+                    <span className="text-gray-300 text-sm">
+                      Toggle the switch to connect
+                    </span>
+                  </div>
+                  <div className="bg-white/5 rounded-lg p-3 border border-white/10">
+                    <div className="flex items-center gap-2 mb-2">
+                      <PlatformIcon deviceType="iphone" className="w-4 h-4" />
+                      <span className="text-gray-300 text-sm">Mobile</span>
+                    </div>
+                    <span className="text-gray-300 text-sm">
+                      Toggle the switch next to your tunnel
+                    </span>
+                  </div>
+                  <div className="bg-white/5 rounded-lg p-3 border border-white/10">
+                    <div className="flex items-center gap-2 mb-2">
+                      <PlatformIcon deviceType="linux" className="w-4 h-4" />
+                      <span className="text-gray-300 text-sm">Linux</span>
+                    </div>
+                    <code className="text-green-400 font-mono text-sm">
+                      sudo wg-quick up nabu-wg
+                    </code>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* QR Code tip for desktop users */}
+            {!isMobile && (
+              <div className="mt-6 p-4 bg-white/5 rounded-lg border border-white/10">
+                <div className="flex items-start gap-3">
+                  <svg className="w-5 h-5 text-purple-400 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v1m6 11h2m-6 0h-2v4m0-11v3m0 0h.01M12 12h4.01M16 20h4M4 12h4m12 0h.01M5 8h2a1 1 0 001-1V5a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1zm12 0h2a1 1 0 001-1V5a1 1 0 00-1-1h-2a1 1 0 00-1 1v2a1 1 0 001 1zM5 20h2a1 1 0 001-1v-2a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1z" />
+                  </svg>
+                  <div>
+                    <p className="text-white font-medium text-sm mb-1">Setting up on mobile?</p>
+                    <p className="text-gray-300 text-sm">
+                      When you get your config from the Account page, you can display a QR code.
+                      Open WireGuard on your mobile device and scan the QR code to import your configuration instantly.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            <div className="mt-6 p-4 bg-white/5 rounded-lg border border-white/10">
+              <div className="flex items-start gap-3">
+                <svg className="w-5 h-5 text-blue-400 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <div>
+                  <p className="text-gray-300 text-sm">
+                    Need more help with WireGuard?
+                    <a
+                      href="https://www.wireguard.com/quickstart/"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-400 hover:text-white transition-colors ml-1"
+                    >
+                      See the official WireGuard quick start guide
+                    </a>
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Collapsed OpenVPN Section - only show when OpenVPN is available */}
+          {isOpenVpnEnabled && (
+            <CollapsibleSection title="Looking for OpenVPN?">
+              <div className="mt-4 p-4 bg-blue-500/10 rounded-lg border border-blue-500/30 mb-6">
+                <div className="flex items-start gap-3">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-6 h-6 text-blue-400 flex-shrink-0">
+                    <path fillRule="evenodd" d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12zm8.706-1.442c1.146-.573 2.437.463 2.126 1.706l-.709 2.836.042-.02a.75.75 0 01.67 1.34l-.04.022c-1.147.573-2.438-.463-2.127-1.706l.71-2.836-.042.02a.75.75 0 11-.671-1.34l.041-.022zM12 9a.75.75 0 100-1.5.75.75 0 000 1.5z" clipRule="evenodd" />
+                  </svg>
+                  <p className="text-gray-300 text-sm">
+                    <span className="text-white font-semibold">We recommend WireGuard</span>{" "}
+                    for better performance and multi-device support. OpenVPN is available
+                    for devices that don't support WireGuard.
+                  </p>
+                </div>
+              </div>
+
+              <OpenVpnContent />
+            </CollapsibleSection>
+          )}
+        </div>
+      </div>
+    </>
+  );
+};
+
+/**
+ * OpenVPN content - extracted from the original InstallGuide
+ */
+const OpenVpnContent = () => {
+  return (
+    <div className="space-y-6">
+      {/* Install OpenVPN */}
+      <div className="bg-white/5 rounded-xl p-6 border border-white/10">
+        <h3 className="text-lg font-semibold text-white mb-4">Install OpenVPN</h3>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div className="bg-white/5 rounded-lg p-4 border border-white/10">
+            <div className="flex items-center gap-3 mb-3">
+              <svg className="w-6 h-6 text-blue-400" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M3 12V6.75l6-1.32v6.48L3 12zm17-9v8.75l-10 .15V5.21L20 3zM3 13l6 .09v6.81l-6-1.15V13zm17 .25V22l-10-1.91v-6.75l10 .15z" />
+              </svg>
+              <h4 className="text-white font-medium">Windows</h4>
+            </div>
+            <a
+              href="https://openvpn.net/client/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-400 hover:text-white transition-colors text-sm"
+            >
+              Download OpenVPN Client
+            </a>
+          </div>
+          <div className="bg-white/5 rounded-lg p-4 border border-white/10">
+            <div className="flex items-center gap-3 mb-3">
+              <svg className="w-6 h-6 text-gray-300" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
+              </svg>
+              <h4 className="text-white font-medium">macOS</h4>
+            </div>
+            <a
+              href="https://openvpn.net/client/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-400 hover:text-white transition-colors text-sm"
+            >
+              Download OpenVPN Client
+            </a>
+          </div>
+          <div className="bg-white/5 rounded-lg p-4 border border-white/10">
+            <div className="flex items-center gap-3 mb-3">
+              <svg className="w-6 h-6 text-orange-400" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12.504 0C5.588 0 0 5.588 0 12.504s5.588 12.504 12.504 12.504S25.008 19.42 25.008 12.504 19.42 0 12.504 0zm0 22.008c-5.243 0-9.504-4.261-9.504-9.504S7.261 3 12.504 3s9.504 4.261 9.504 9.504-4.261 9.504-9.504 9.504z" />
+              </svg>
+              <h4 className="text-white font-medium">Linux</h4>
+            </div>
+            <code className="text-green-400 font-mono text-sm">
+              sudo apt install openvpn
+            </code>
+          </div>
+          <div className="bg-white/5 rounded-lg p-4 border border-white/10">
+            <div className="flex items-center gap-3 mb-3">
+              <svg className="w-6 h-6 text-green-400" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M17 1.01L7 1c-1.1 0-1.99.9-1.99 2v18c0 1.1.89 2 2 2h10c1.1 0 2-.9 2-2V3c0-1.1-.9-1.99-2-1.99zM17 19H7V5h10v14z" />
+              </svg>
+              <h4 className="text-white font-medium">Mobile</h4>
+            </div>
+            <a
+              href="https://play.google.com/store/apps/details?id=net.openvpn.openvpn"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-400 hover:text-white transition-colors text-sm"
+            >
+              Android/iOS App
+            </a>
+          </div>
+        </div>
+      </div>
+
+      {/* Configure OpenVPN */}
+      <div className="bg-white/5 rounded-xl p-6 border border-white/10">
+        <h3 className="text-lg font-semibold text-white mb-4">Configure & Connect</h3>
+        <div className="space-y-3">
+          <div className="bg-white/5 rounded-lg p-3 border border-white/10">
+            <div className="flex items-center gap-2 mb-2">
+              <svg className="w-4 h-4 text-blue-400" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M3 12V6.75l6-1.32v6.48L3 12zm17-9v8.75l-10 .15V5.21L20 3zM3 13l6 .09v6.81l-6-1.15V13zm17 .25V22l-10-1.91v-6.75l10 .15z" />
+              </svg>
+              <span className="text-gray-300 text-sm">Windows</span>
+            </div>
+            <code className="text-gray-300 font-mono text-sm">
+              C:\Program Files\OpenVPN\config\
+            </code>
+          </div>
+          <div className="bg-white/5 rounded-lg p-3 border border-white/10">
+            <div className="flex items-center gap-2 mb-2">
+              <svg className="w-4 h-4 text-orange-400" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12.504 0C5.588 0 0 5.588 0 12.504s5.588 12.504 12.504 12.504S25.008 19.42 25.008 12.504 19.42 0 12.504 0zm0 22.008c-5.243 0-9.504-4.261-9.504-9.504S7.261 3 12.504 3s9.504 4.261 9.504 9.504-4.261 9.504-9.504 9.504z" />
+              </svg>
+              <span className="text-gray-300 text-sm">Linux/Mac</span>
+            </div>
+            <code className="text-green-400 font-mono text-sm">
+              sudo openvpn --config /path/to/your-profile.ovpn
+            </code>
+          </div>
+          <div className="bg-white/5 rounded-lg p-3 border border-white/10">
+            <div className="flex items-center gap-2 mb-2">
+              <svg className="w-4 h-4 text-green-400" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M17 1.01L7 1c-1.1 0-1.99.9-1.99 2v18c0 1.1.89 2 2 2h10c1.1 0 2-.9 2-2V3c0-1.1-.9-1.99-2-1.99zM17 19H7V5h10v14z" />
+              </svg>
+              <span className="text-gray-300 text-sm">Mobile</span>
+            </div>
+            <span className="text-gray-300 text-sm">Import into OpenVPN Connect app</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="p-4 bg-white/5 rounded-lg border border-white/10">
+        <div className="flex items-start gap-3">
+          <svg className="w-5 h-5 text-blue-400 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <div>
+            <p className="text-gray-300 text-sm">
+              Still have questions on how to use OpenVPN?
+              <a
+                href="https://openvpn.net/connect-docs/user-guide.html"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-400 hover:text-white transition-colors ml-1"
+              >
+                See the OpenVPN user guides here
+              </a>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Original OpenVPN Install Guide (shown when WireGuard is disabled)
+ */
+const OpenVpnInstallGuide = () => {
+  return (
+    <>
+      <div className="flex flex-col sm:flex-row items-center justify-center gap-8 mb-8">
+        <div className="flex items-center gap-3">
+          <div className="w-8 h-8 bg-white rounded-full flex items-center justify-center">
+            <span className="text-black font-bold text-sm">1</span>
+          </div>
+          <span className="text-white font-medium">Install OpenVPN</span>
+        </div>
+        <div className="flex items-center gap-3">
+          <div className="w-8 h-8 bg-white rounded-full flex items-center justify-center">
+            <span className="text-black font-bold text-sm">2</span>
+          </div>
+          <span className="text-white font-medium">Download Profile</span>
+        </div>
+        <div className="flex items-center gap-3">
+          <div className="w-8 h-8 bg-white rounded-full flex items-center justify-center">
+            <span className="text-black font-bold text-sm">3</span>
+          </div>
+          <span className="text-white font-medium">Configure & Connect</span>
+        </div>
+      </div>
+
+      <div className="bg-gradient-to-br from-[#00000066] to-[#1a1a2e66] rounded-2xl p-8 backdrop-blur-xl border border-[#ffffff2a] shadow-2xl">
+        <div className="space-y-8 mb-12">
           <div className="bg-white/10 rounded-2xl p-8 backdrop-blur-xl border border-white/20">
             <div className="flex items-center gap-4 mb-6">
               <div className="w-12 h-12 bg-white rounded-full flex items-center justify-center">
@@ -50,11 +797,7 @@ const InstallGuide = () => {
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
               <div className="bg-white/5 rounded-xl p-6 border border-white/10">
                 <div className="flex items-center gap-3 mb-4">
-                  <svg
-                    className="w-8 h-8 text-blue-400"
-                    viewBox="0 0 24 24"
-                    fill="currentColor"
-                  >
+                  <svg className="w-8 h-8 text-blue-400" viewBox="0 0 24 24" fill="currentColor">
                     <path d="M3 12V6.75l6-1.32v6.48L3 12zm17-9v8.75l-10 .15V5.21L20 3zM3 13l6 .09v6.81l-6-1.15V13zm17 .25V22l-10-1.91v-6.75l10 .15z" />
                   </svg>
                   <h3 className="text-lg font-semibold text-white">Windows</h3>
@@ -66,18 +809,8 @@ const InstallGuide = () => {
                     rel="noopener noreferrer"
                     className="inline-flex items-center gap-2 text-blue-400 hover:text-white transition-colors"
                   >
-                    <svg
-                      className="w-4 h-4"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-                      />
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
                     </svg>
                     Download OpenVPN Client
                   </a>
@@ -87,18 +820,8 @@ const InstallGuide = () => {
                     rel="noopener noreferrer"
                     className="inline-flex items-center gap-2 text-gray-300 hover:text-white transition-colors text-sm"
                   >
-                    <svg
-                      className="w-4 h-4"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-                      />
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
                     </svg>
                     Windows Documentation
                   </a>
@@ -107,11 +830,7 @@ const InstallGuide = () => {
 
               <div className="bg-white/5 rounded-xl p-6 border border-white/10">
                 <div className="flex items-center gap-3 mb-4">
-                  <svg
-                    className="w-8 h-8 text-gray-300"
-                    viewBox="0 0 24 24"
-                    fill="currentColor"
-                  >
+                  <svg className="w-8 h-8 text-gray-300" viewBox="0 0 24 24" fill="currentColor">
                     <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
                   </svg>
                   <h3 className="text-lg font-semibold text-white">macOS</h3>
@@ -123,18 +842,8 @@ const InstallGuide = () => {
                     rel="noopener noreferrer"
                     className="inline-flex items-center gap-2 text-blue-400 hover:text-white transition-colors"
                   >
-                    <svg
-                      className="w-4 h-4"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-                      />
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
                     </svg>
                     Download OpenVPN Client
                   </a>
@@ -144,18 +853,8 @@ const InstallGuide = () => {
                     rel="noopener noreferrer"
                     className="inline-flex items-center gap-2 text-gray-300 hover:text-white transition-colors text-sm"
                   >
-                    <svg
-                      className="w-4 h-4"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-                      />
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
                     </svg>
                     macOS Documentation
                   </a>
@@ -164,11 +863,7 @@ const InstallGuide = () => {
 
               <div className="bg-white/5 rounded-xl p-6 border border-white/10">
                 <div className="flex items-center gap-3 mb-4">
-                  <svg
-                    className="w-8 h-8 text-orange-400"
-                    viewBox="0 0 24 24"
-                    fill="currentColor"
-                  >
+                  <svg className="w-8 h-8 text-orange-400" viewBox="0 0 24 24" fill="currentColor">
                     <path d="M12.504 0C5.588 0 0 5.588 0 12.504s5.588 12.504 12.504 12.504S25.008 19.42 25.008 12.504 19.42 0 12.504 0zm0 22.008c-5.243 0-9.504-4.261-9.504-9.504S7.261 3 12.504 3s9.504 4.261 9.504 9.504-4.261 9.504-9.504 9.504z" />
                   </svg>
                   <h3 className="text-lg font-semibold text-white">Linux</h3>
@@ -176,37 +871,19 @@ const InstallGuide = () => {
                 <div className="space-y-3">
                   <div className="bg-white/5 rounded-lg p-3 border border-white/10">
                     <div className="flex items-center gap-2 mb-2">
-                      <svg
-                        className="w-4 h-4 text-green-400"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-                        />
+                      <svg className="w-4 h-4 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
                       </svg>
-                      <span className="text-gray-300 text-sm font-mono">
-                        Terminal Command
-                      </span>
+                      <span className="text-gray-300 text-sm font-mono">Terminal Command</span>
                     </div>
-                    <code className="text-green-400 font-mono text-sm">
-                      sudo apt install openvpn
-                    </code>
+                    <code className="text-green-400 font-mono text-sm">sudo apt install openvpn</code>
                   </div>
                 </div>
               </div>
 
               <div className="bg-white/5 rounded-xl p-6 border border-white/10">
                 <div className="flex items-center gap-3 mb-4">
-                  <svg
-                    className="w-8 h-8 text-green-400"
-                    viewBox="0 0 24 24"
-                    fill="currentColor"
-                  >
+                  <svg className="w-8 h-8 text-green-400" viewBox="0 0 24 24" fill="currentColor">
                     <path d="M17 1.01L7 1c-1.1 0-1.99.9-1.99 2v18c0 1.1.89 2 2 2h10c1.1 0 2-.9 2-2V3c0-1.1-.9-1.99-2-1.99zM17 19H7V5h10v14z" />
                   </svg>
                   <h3 className="text-lg font-semibold text-white">Mobile</h3>
@@ -218,18 +895,8 @@ const InstallGuide = () => {
                     rel="noopener noreferrer"
                     className="inline-flex items-center gap-2 text-blue-400 hover:text-white transition-colors"
                   >
-                    <svg
-                      className="w-4 h-4"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"
-                      />
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z" />
                     </svg>
                     Android/iOS App
                   </a>
@@ -239,18 +906,8 @@ const InstallGuide = () => {
                     rel="noopener noreferrer"
                     className="inline-flex items-center gap-2 text-gray-300 hover:text-white transition-colors text-sm"
                   >
-                    <svg
-                      className="w-4 h-4"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-                      />
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
                     </svg>
                     Mobile Documentation
                   </a>
@@ -264,50 +921,25 @@ const InstallGuide = () => {
               <div className="w-12 h-12 bg-white rounded-full flex items-center justify-center">
                 <span className="text-black font-bold text-lg">2</span>
               </div>
-              <h2 className="text-2xl font-bold text-white">
-                Download Your VPN Profile
-              </h2>
+              <h2 className="text-2xl font-bold text-white">Download Your VPN Profile</h2>
             </div>
 
             <div className="bg-white/5 rounded-xl p-6 border border-white/10">
               <div className="flex items-center gap-3 mb-4">
-                <svg
-                  className="w-8 h-8 text-purple-400"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
-                  />
+                <svg className="w-8 h-8 text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
                 </svg>
-                <h3 className="text-lg font-semibold text-white">
-                  Connect Wallet & Purchase
-                </h3>
+                <h3 className="text-lg font-semibold text-white">Connect Wallet & Purchase</h3>
               </div>
               <p className="text-gray-300 mb-4">
-                Go to your account page and connect your Cardano wallet to
-                purchase your VPN profile.
+                Go to your account page and connect your Cardano wallet to purchase your VPN profile.
               </p>
               <Link
                 to="/account"
                 className="inline-flex items-center gap-2 px-6 py-3 bg-white text-black font-semibold rounded-lg hover:bg-gray-100 transition-all duration-200"
               >
-                <svg
-                  className="w-5 h-5"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M13 7l5 5m0 0l-5 5m5-5H6"
-                  />
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
                 </svg>
                 Go to Account Page
               </Link>
@@ -319,62 +951,29 @@ const InstallGuide = () => {
               <div className="w-12 h-12 bg-white rounded-full flex items-center justify-center">
                 <span className="text-black font-bold text-lg">3</span>
               </div>
-              <h2 className="text-2xl font-bold text-white">
-                Configure & Connect
-              </h2>
+              <h2 className="text-2xl font-bold text-white">Configure & Connect</h2>
             </div>
 
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
               <div className="bg-white/5 rounded-xl p-6 border border-white/10">
                 <div className="flex items-center gap-3 mb-4">
-                  <svg
-                    className="w-8 h-8 text-blue-400"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
-                    />
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-                    />
+                  <svg className="w-8 h-8 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
                   </svg>
-                  <h3 className="text-lg font-semibold text-white">
-                    Configuration
-                  </h3>
+                  <h3 className="text-lg font-semibold text-white">Configuration</h3>
                 </div>
                 <div className="space-y-4">
                   <div className="bg-white/5 rounded-lg p-3 border border-white/10">
                     <div className="flex items-center gap-2 mb-2">
-                      <svg
-                        className="w-4 h-4 text-blue-400"
-                        viewBox="0 0 24 24"
-                        fill="currentColor"
-                      >
+                      <svg className="w-4 h-4 text-blue-400" viewBox="0 0 24 24" fill="currentColor">
                         <path d="M3 12V6.75l6-1.32v6.48L3 12zm17-9v8.75l-10 .15V5.21L20 3zM3 13l6 .09v6.81l-6-1.15V13zm17 .25V22l-10-1.91v-6.75l10 .15z" />
                       </svg>
                       <span className="text-gray-300 text-sm">Windows</span>
                     </div>
                     <div className="flex items-center gap-2">
-                      <svg
-                        className="w-4 h-4 text-yellow-400"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-                        />
+                      <svg className="w-4 h-4 text-yellow-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
                       </svg>
                       <code className="text-gray-300 font-mono text-sm">
                         C:\Program Files\OpenVPN\config\
@@ -384,11 +983,7 @@ const InstallGuide = () => {
 
                   <div className="bg-white/5 rounded-lg p-3 border border-white/10">
                     <div className="flex items-center gap-2 mb-2">
-                      <svg
-                        className="w-4 h-4 text-orange-400"
-                        viewBox="0 0 24 24"
-                        fill="currentColor"
-                      >
+                      <svg className="w-4 h-4 text-orange-400" viewBox="0 0 24 24" fill="currentColor">
                         <path d="M12.504 0C5.588 0 0 5.588 0 12.504s5.588 12.504 12.504 12.504S25.008 19.42 25.008 12.504 19.42 0 12.504 0zm0 22.008c-5.243 0-9.504-4.261-9.504-9.504S7.261 3 12.504 3s9.504 4.261 9.504 9.504-4.261 9.504-9.504 9.504z" />
                       </svg>
                       <span className="text-gray-300 text-sm">Linux/Mac</span>
@@ -400,65 +995,37 @@ const InstallGuide = () => {
 
                   <div className="bg-white/5 rounded-lg p-3 border border-white/10">
                     <div className="flex items-center gap-2 mb-2">
-                      <svg
-                        className="w-4 h-4 text-green-400"
-                        viewBox="0 0 24 24"
-                        fill="currentColor"
-                      >
+                      <svg className="w-4 h-4 text-green-400" viewBox="0 0 24 24" fill="currentColor">
                         <path d="M17 1.01L7 1c-1.1 0-1.99.9-1.99 2v18c0 1.1.89 2 2 2h10c1.1 0 2-.9 2-2V3c0-1.1-.9-1.99-2-1.99zM17 19H7V5h10v14z" />
                       </svg>
                       <span className="text-gray-300 text-sm">Mobile</span>
                     </div>
-                    <span className="text-gray-300 text-sm">
-                      Import into OpenVPN Connect app
-                    </span>
+                    <span className="text-gray-300 text-sm">Import into OpenVPN Connect app</span>
                   </div>
                 </div>
               </div>
 
               <div className="bg-white/5 rounded-xl p-6 border border-white/10">
                 <div className="flex items-center gap-3 mb-4">
-                  <svg
-                    className="w-8 h-8 text-green-400"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M13 10V3L4 14h7v7l9-11h-7z"
-                    />
+                  <svg className="w-8 h-8 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
                   </svg>
-                  <h3 className="text-lg font-semibold text-white">
-                    Connection
-                  </h3>
+                  <h3 className="text-lg font-semibold text-white">Connection</h3>
                 </div>
                 <div className="space-y-4">
                   <div className="bg-white/5 rounded-lg p-3 border border-white/10">
                     <div className="flex items-center gap-2 mb-2">
-                      <svg
-                        className="w-4 h-4 text-blue-400"
-                        viewBox="0 0 24 24"
-                        fill="currentColor"
-                      >
+                      <svg className="w-4 h-4 text-blue-400" viewBox="0 0 24 24" fill="currentColor">
                         <path d="M3 12V6.75l6-1.32v6.48L3 12zm17-9v8.75l-10 .15V5.21L20 3zM3 13l6 .09v6.81l-6-1.15V13zm17 .25V22l-10-1.91v-6.75l10 .15z" />
                       </svg>
                       <span className="text-gray-300 text-sm">Windows</span>
                     </div>
-                    <span className="text-gray-300 text-sm">
-                      Right-click GUI and select "Connect"
-                    </span>
+                    <span className="text-gray-300 text-sm">Right-click GUI and select "Connect"</span>
                   </div>
 
                   <div className="bg-white/5 rounded-lg p-3 border border-white/10">
                     <div className="flex items-center gap-2 mb-2">
-                      <svg
-                        className="w-4 h-4 text-orange-400"
-                        viewBox="0 0 24 24"
-                        fill="currentColor"
-                      >
+                      <svg className="w-4 h-4 text-orange-400" viewBox="0 0 24 24" fill="currentColor">
                         <path d="M12.504 0C5.588 0 0 5.588 0 12.504s5.588 12.504 12.504 12.504S25.008 19.42 25.008 12.504 19.42 0 12.504 0zm0 22.008c-5.243 0-9.504-4.261-9.504-9.504S7.261 3 12.504 3s9.504 4.261 9.504 9.504-4.261 9.504-9.504 9.504z" />
                       </svg>
                       <span className="text-gray-300 text-sm">Linux/Mac</span>
@@ -470,18 +1037,12 @@ const InstallGuide = () => {
 
                   <div className="bg-white/5 rounded-lg p-3 border border-white/10">
                     <div className="flex items-center gap-2 mb-2">
-                      <svg
-                        className="w-4 h-4 text-green-400"
-                        viewBox="0 0 24 24"
-                        fill="currentColor"
-                      >
+                      <svg className="w-4 h-4 text-green-400" viewBox="0 0 24 24" fill="currentColor">
                         <path d="M17 1.01L7 1c-1.1 0-1.99.9-1.99 2v18c0 1.1.89 2 2 2h10c1.1 0 2-.9 2-2V3c0-1.1-.9-1.99-2-1.99zM17 19H7V5h10v14z" />
                       </svg>
                       <span className="text-gray-300 text-sm">Mobile</span>
                     </div>
-                    <span className="text-gray-300 text-sm">
-                      Tap "Connect" in the app
-                    </span>
+                    <span className="text-gray-300 text-sm">Tap "Connect" in the app</span>
                   </div>
                 </div>
               </div>
@@ -489,18 +1050,8 @@ const InstallGuide = () => {
 
             <div className="mt-6 p-4 bg-white/5 rounded-lg border border-white/10">
               <div className="flex items-start gap-3">
-                <svg
-                  className="w-5 h-5 text-blue-400 mt-0.5 flex-shrink-0"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                  />
+                <svg className="w-5 h-5 text-blue-400 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
                 <div>
                   <p className="text-gray-300 text-sm">
@@ -519,7 +1070,27 @@ const InstallGuide = () => {
             </div>
           </div>
         </div>
+      </div>
+    </>
+  );
+};
+
+const InstallGuide = () => {
+  return (
+    <div className="flex flex-col relative pt-16 min-h-screen overflow-hidden">
+      <div className="max-w-4xl mx-auto px-6 py-12 relative z-10">
+        <div className="text-center mb-12">
+          <h1 className="text-5xl font-bold bg-gradient-to-r from-white via-blue-200 to-purple-200 bg-clip-text text-transparent mb-4">
+            How to Install NABU VPN
+          </h1>
+          <p className="text-gray-300 text-lg mb-8">
+            {isWireGuardEnabled
+              ? "Follow these steps to install WireGuard and connect with your NABU subscription on any device."
+              : "Follow these steps to install OpenVPN and connect with your NABU profile on any device."}
+          </p>
         </div>
+
+        {isWireGuardEnabled ? <WireGuardInstallGuide /> : <OpenVpnInstallGuide />}
 
         <div className="text-center mt-8">
           <Link
@@ -527,18 +1098,8 @@ const InstallGuide = () => {
             className="inline-flex items-center px-8 py-4 text-white border border-white/20 backdrop-blur-sm font-semibold rounded-xl shadow-lg hover:bg-gray-800 transition-colors"
           >
             <span className="mr-2">Read FAQs</span>
-            <svg
-              className="w-5 h-5"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M13 7l5 5m0 0l-5 5m5-5H6"
-              />
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
             </svg>
           </Link>
         </div>
@@ -548,4 +1109,3 @@ const InstallGuide = () => {
 };
 
 export default InstallGuide;
-

--- a/src/utils/__tests__/deviceDetection.test.ts
+++ b/src/utils/__tests__/deviceDetection.test.ts
@@ -1,0 +1,393 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// Helper to reset the module cache between tests
+const resetModule = async () => {
+  vi.resetModules();
+  const module = await import("../deviceDetection");
+  return module;
+};
+
+describe("deviceDetection utilities", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("detectDeviceTypeRaw", () => {
+    it("should return 'unknown' when navigator is undefined", async () => {
+      vi.stubGlobal("navigator", undefined);
+
+      const { detectDeviceTypeRaw } = await resetModule();
+      expect(detectDeviceTypeRaw()).toBe("unknown");
+    });
+
+    it("should return 'iphone' for iPhone user agent", async () => {
+      vi.stubGlobal("navigator", {
+        userAgent:
+          "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+        platform: "iPhone",
+        maxTouchPoints: 5,
+      });
+
+      const { detectDeviceTypeRaw } = await resetModule();
+      expect(detectDeviceTypeRaw()).toBe("iphone");
+    });
+
+    it("should return 'ipad' for iPad user agent", async () => {
+      vi.stubGlobal("navigator", {
+        userAgent:
+          "Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+        platform: "iPad",
+        maxTouchPoints: 5,
+      });
+
+      const { detectDeviceTypeRaw } = await resetModule();
+      expect(detectDeviceTypeRaw()).toBe("ipad");
+    });
+
+    it("should return 'ipad' for iPadOS 13+ (desktop Safari UA with touch)", async () => {
+      vi.stubGlobal("navigator", {
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+        platform: "MacIntel",
+        maxTouchPoints: 5,
+      });
+
+      const { detectDeviceTypeRaw } = await resetModule();
+      expect(detectDeviceTypeRaw()).toBe("ipad");
+    });
+
+    it("should return 'mac' for macOS desktop user agent", async () => {
+      vi.stubGlobal("navigator", {
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+        platform: "MacIntel",
+        maxTouchPoints: 0,
+      });
+
+      const { detectDeviceTypeRaw } = await resetModule();
+      expect(detectDeviceTypeRaw()).toBe("mac");
+    });
+
+    it("should return 'windows' for Windows user agent", async () => {
+      vi.stubGlobal("navigator", {
+        userAgent:
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+        platform: "Win32",
+        maxTouchPoints: 0,
+      });
+
+      const { detectDeviceTypeRaw } = await resetModule();
+      expect(detectDeviceTypeRaw()).toBe("windows");
+    });
+
+    it("should return 'android' for Android user agent", async () => {
+      vi.stubGlobal("navigator", {
+        userAgent:
+          "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36",
+        platform: "Linux armv8l",
+        maxTouchPoints: 5,
+      });
+
+      const { detectDeviceTypeRaw } = await resetModule();
+      expect(detectDeviceTypeRaw()).toBe("android");
+    });
+
+    it("should return 'linux' for Linux desktop user agent", async () => {
+      vi.stubGlobal("navigator", {
+        userAgent:
+          "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+        platform: "Linux x86_64",
+        maxTouchPoints: 0,
+      });
+
+      const { detectDeviceTypeRaw } = await resetModule();
+      expect(detectDeviceTypeRaw()).toBe("linux");
+    });
+
+    it("should return 'unknown' for unrecognized user agent", async () => {
+      vi.stubGlobal("navigator", {
+        userAgent: "SomeCustomBrowser/1.0",
+        platform: "unknown",
+        maxTouchPoints: 0,
+      });
+
+      const { detectDeviceTypeRaw } = await resetModule();
+      expect(detectDeviceTypeRaw()).toBe("unknown");
+    });
+  });
+
+  describe("detectDeviceType", () => {
+    it("should return 'iPhone' for iPhone device", async () => {
+      vi.stubGlobal("navigator", {
+        userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)",
+        platform: "iPhone",
+        maxTouchPoints: 5,
+      });
+
+      const { detectDeviceType } = await resetModule();
+      expect(detectDeviceType()).toBe("iPhone");
+    });
+
+    it("should return 'iPad' for iPad device", async () => {
+      vi.stubGlobal("navigator", {
+        userAgent: "Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X)",
+        platform: "iPad",
+        maxTouchPoints: 5,
+      });
+
+      const { detectDeviceType } = await resetModule();
+      expect(detectDeviceType()).toBe("iPad");
+    });
+
+    it("should return 'MacBook' for macOS device", async () => {
+      vi.stubGlobal("navigator", {
+        userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+        platform: "MacIntel",
+        maxTouchPoints: 0,
+      });
+
+      const { detectDeviceType } = await resetModule();
+      expect(detectDeviceType()).toBe("MacBook");
+    });
+
+    it("should return 'Windows PC' for Windows device", async () => {
+      vi.stubGlobal("navigator", {
+        userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+        platform: "Win32",
+        maxTouchPoints: 0,
+      });
+
+      const { detectDeviceType } = await resetModule();
+      expect(detectDeviceType()).toBe("Windows PC");
+    });
+
+    it("should return 'Android Phone' for Android device", async () => {
+      vi.stubGlobal("navigator", {
+        userAgent: "Mozilla/5.0 (Linux; Android 14; Pixel 8)",
+        platform: "Linux armv8l",
+        maxTouchPoints: 5,
+      });
+
+      const { detectDeviceType } = await resetModule();
+      expect(detectDeviceType()).toBe("Android Phone");
+    });
+
+    it("should return 'Linux Desktop' for Linux device", async () => {
+      vi.stubGlobal("navigator", {
+        userAgent: "Mozilla/5.0 (X11; Linux x86_64)",
+        platform: "Linux x86_64",
+        maxTouchPoints: 0,
+      });
+
+      const { detectDeviceType } = await resetModule();
+      expect(detectDeviceType()).toBe("Linux Desktop");
+    });
+
+    it("should return 'Device' for unknown device type", async () => {
+      vi.stubGlobal("navigator", {
+        userAgent: "UnknownBrowser/1.0",
+        platform: "unknown",
+        maxTouchPoints: 0,
+      });
+
+      const { detectDeviceType } = await resetModule();
+      expect(detectDeviceType()).toBe("Device");
+    });
+  });
+
+  describe("getDeviceIcon", () => {
+    it("should return mobile phone emoji for iPhone", async () => {
+      vi.stubGlobal("navigator", {
+        userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0)",
+        platform: "iPhone",
+        maxTouchPoints: 5,
+      });
+
+      const { getDeviceIcon } = await resetModule();
+      expect(getDeviceIcon()).toBe("\u{1F4F1}");
+    });
+
+    it("should return mobile phone emoji for Android", async () => {
+      vi.stubGlobal("navigator", {
+        userAgent: "Mozilla/5.0 (Linux; Android 14)",
+        platform: "Linux armv8l",
+        maxTouchPoints: 5,
+      });
+
+      const { getDeviceIcon } = await resetModule();
+      expect(getDeviceIcon()).toBe("\u{1F4F1}");
+    });
+
+    it("should return tablet emoji for iPad", async () => {
+      vi.stubGlobal("navigator", {
+        userAgent: "Mozilla/5.0 (iPad; CPU OS 17_0)",
+        platform: "iPad",
+        maxTouchPoints: 5,
+      });
+
+      const { getDeviceIcon } = await resetModule();
+      expect(getDeviceIcon()).toBe("\u{1F4F2}");
+    });
+
+    it("should return laptop emoji for Mac", async () => {
+      vi.stubGlobal("navigator", {
+        userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+        platform: "MacIntel",
+        maxTouchPoints: 0,
+      });
+
+      const { getDeviceIcon } = await resetModule();
+      expect(getDeviceIcon()).toBe("\u{1F4BB}");
+    });
+
+    it("should return laptop emoji for Windows", async () => {
+      vi.stubGlobal("navigator", {
+        userAgent: "Mozilla/5.0 (Windows NT 10.0)",
+        platform: "Win32",
+        maxTouchPoints: 0,
+      });
+
+      const { getDeviceIcon } = await resetModule();
+      expect(getDeviceIcon()).toBe("\u{1F4BB}");
+    });
+
+    it("should return laptop emoji for Linux", async () => {
+      vi.stubGlobal("navigator", {
+        userAgent: "Mozilla/5.0 (X11; Linux x86_64)",
+        platform: "Linux x86_64",
+        maxTouchPoints: 0,
+      });
+
+      const { getDeviceIcon } = await resetModule();
+      expect(getDeviceIcon()).toBe("\u{1F4BB}");
+    });
+
+    it("should return desktop computer emoji for unknown device", async () => {
+      vi.stubGlobal("navigator", {
+        userAgent: "UnknownBrowser/1.0",
+        platform: "unknown",
+        maxTouchPoints: 0,
+      });
+
+      const { getDeviceIcon } = await resetModule();
+      expect(getDeviceIcon()).toBe("\u{1F5A5}");
+    });
+  });
+
+  describe("inferDeviceTypeFromName", () => {
+    beforeEach(async () => {
+      // Set up a default navigator for inferDeviceTypeFromName tests
+      vi.stubGlobal("navigator", {
+        userAgent: "Mozilla/5.0",
+        platform: "unknown",
+        maxTouchPoints: 0,
+      });
+    });
+
+    it("should return 'iphone' for name containing 'iphone'", async () => {
+      const { inferDeviceTypeFromName } = await resetModule();
+      expect(inferDeviceTypeFromName("My iPhone")).toBe("iphone");
+      expect(inferDeviceTypeFromName("IPHONE 15")).toBe("iphone");
+      expect(inferDeviceTypeFromName("iphone-work")).toBe("iphone");
+    });
+
+    it("should return 'ipad' for name containing 'ipad'", async () => {
+      const { inferDeviceTypeFromName } = await resetModule();
+      expect(inferDeviceTypeFromName("My iPad")).toBe("ipad");
+      expect(inferDeviceTypeFromName("IPAD Pro")).toBe("ipad");
+      expect(inferDeviceTypeFromName("ipad-home")).toBe("ipad");
+    });
+
+    it("should return 'mac' for name containing 'mac' or 'macbook'", async () => {
+      const { inferDeviceTypeFromName } = await resetModule();
+      expect(inferDeviceTypeFromName("MacBook Pro")).toBe("mac");
+      expect(inferDeviceTypeFromName("My Mac")).toBe("mac");
+      expect(inferDeviceTypeFromName("mac mini")).toBe("mac");
+      expect(inferDeviceTypeFromName("MACBOOK Air")).toBe("mac");
+    });
+
+    it("should return 'windows' for name containing 'windows' or 'pc'", async () => {
+      const { inferDeviceTypeFromName } = await resetModule();
+      expect(inferDeviceTypeFromName("Windows Desktop")).toBe("windows");
+      expect(inferDeviceTypeFromName("My PC")).toBe("windows");
+      expect(inferDeviceTypeFromName("Office PC")).toBe("windows");
+      expect(inferDeviceTypeFromName("WINDOWS laptop")).toBe("windows");
+    });
+
+    it("should return 'android' for name containing 'android'", async () => {
+      const { inferDeviceTypeFromName } = await resetModule();
+      expect(inferDeviceTypeFromName("Android Phone")).toBe("android");
+      expect(inferDeviceTypeFromName("My ANDROID")).toBe("android");
+      expect(inferDeviceTypeFromName("android-tablet")).toBe("android");
+    });
+
+    it("should return 'linux' for name containing 'linux', 'ubuntu', or 'debian'", async () => {
+      const { inferDeviceTypeFromName } = await resetModule();
+      expect(inferDeviceTypeFromName("Linux Server")).toBe("linux");
+      expect(inferDeviceTypeFromName("Ubuntu Desktop")).toBe("linux");
+      expect(inferDeviceTypeFromName("Debian Box")).toBe("linux");
+      expect(inferDeviceTypeFromName("my LINUX laptop")).toBe("linux");
+    });
+
+    it("should return 'unknown' for unrecognized names", async () => {
+      const { inferDeviceTypeFromName } = await resetModule();
+      expect(inferDeviceTypeFromName("My Device")).toBe("unknown");
+      expect(inferDeviceTypeFromName("Home")).toBe("unknown");
+      expect(inferDeviceTypeFromName("Work Computer")).toBe("unknown");
+      expect(inferDeviceTypeFromName("")).toBe("unknown");
+    });
+
+    it("should be case-insensitive", async () => {
+      const { inferDeviceTypeFromName } = await resetModule();
+      expect(inferDeviceTypeFromName("IPHONE")).toBe("iphone");
+      expect(inferDeviceTypeFromName("iphone")).toBe("iphone");
+      expect(inferDeviceTypeFromName("IPhone")).toBe("iphone");
+      expect(inferDeviceTypeFromName("iPHONE")).toBe("iphone");
+    });
+  });
+
+  describe("getDeviceIconFromName", () => {
+    beforeEach(async () => {
+      vi.stubGlobal("navigator", {
+        userAgent: "Mozilla/5.0",
+        platform: "unknown",
+        maxTouchPoints: 0,
+      });
+    });
+
+    it("should return mobile phone emoji for iPhone name", async () => {
+      const { getDeviceIconFromName } = await resetModule();
+      expect(getDeviceIconFromName("My iPhone")).toBe("\u{1F4F1}");
+    });
+
+    it("should return mobile phone emoji for Android name", async () => {
+      const { getDeviceIconFromName } = await resetModule();
+      expect(getDeviceIconFromName("Android Phone")).toBe("\u{1F4F1}");
+    });
+
+    it("should return tablet emoji for iPad name", async () => {
+      const { getDeviceIconFromName } = await resetModule();
+      expect(getDeviceIconFromName("iPad Pro")).toBe("\u{1F4F2}");
+    });
+
+    it("should return laptop emoji for Mac name", async () => {
+      const { getDeviceIconFromName } = await resetModule();
+      expect(getDeviceIconFromName("MacBook")).toBe("\u{1F4BB}");
+    });
+
+    it("should return laptop emoji for Windows name", async () => {
+      const { getDeviceIconFromName } = await resetModule();
+      expect(getDeviceIconFromName("Windows PC")).toBe("\u{1F4BB}");
+    });
+
+    it("should return laptop emoji for Linux name", async () => {
+      const { getDeviceIconFromName } = await resetModule();
+      expect(getDeviceIconFromName("Linux Desktop")).toBe("\u{1F4BB}");
+    });
+
+    it("should return desktop computer emoji for unknown name", async () => {
+      const { getDeviceIconFromName } = await resetModule();
+      expect(getDeviceIconFromName("My Device")).toBe("\u{1F5A5}");
+    });
+  });
+});

--- a/src/utils/__tests__/deviceNames.test.ts
+++ b/src/utils/__tests__/deviceNames.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  getDeviceName,
+  setDeviceName,
+  removeDeviceName,
+  getAllDeviceNames,
+} from "../deviceNames";
+
+describe("deviceNames utilities", () => {
+  const STORAGE_KEY = "wg-device-names";
+
+  // Mock localStorage
+  let mockStorage: Record<string, string> = {};
+
+  beforeEach(() => {
+    mockStorage = {};
+
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(
+      (key: string) => mockStorage[key] || null,
+    );
+
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(
+      (key: string, value: string) => {
+        mockStorage[key] = value;
+      },
+    );
+
+    vi.spyOn(Storage.prototype, "removeItem").mockImplementation(
+      (key: string) => {
+        delete mockStorage[key];
+      },
+    );
+
+    vi.clearAllMocks();
+  });
+
+  describe("getDeviceName", () => {
+    it("should return null for unknown pubkey", () => {
+      const result = getDeviceName("unknown-pubkey");
+      expect(result).toBeNull();
+    });
+
+    it("should return null when localStorage is empty", () => {
+      const result = getDeviceName("some-pubkey");
+      expect(result).toBeNull();
+    });
+
+    it("should return the stored name for a known pubkey", () => {
+      const pubkey = "test-pubkey-123";
+      const deviceName = "My iPhone";
+      mockStorage[STORAGE_KEY] = JSON.stringify({
+        [pubkey]: { name: deviceName, createdAt: "2024-01-01T00:00:00.000Z" },
+      });
+
+      const result = getDeviceName(pubkey);
+      expect(result).toBe(deviceName);
+    });
+
+    it("should return null when pubkey exists but has no name field", () => {
+      const pubkey = "test-pubkey-123";
+      mockStorage[STORAGE_KEY] = JSON.stringify({
+        [pubkey]: { createdAt: "2024-01-01T00:00:00.000Z" },
+      });
+
+      const result = getDeviceName(pubkey);
+      expect(result).toBeNull();
+    });
+
+    it("should return null and log error when localStorage contains invalid JSON", () => {
+      mockStorage[STORAGE_KEY] = "invalid-json";
+
+      const result = getDeviceName("some-pubkey");
+      expect(result).toBeNull();
+    });
+
+    it("should return the correct name when multiple devices exist", () => {
+      const pubkey1 = "pubkey-1";
+      const pubkey2 = "pubkey-2";
+      mockStorage[STORAGE_KEY] = JSON.stringify({
+        [pubkey1]: { name: "Device 1", createdAt: "2024-01-01T00:00:00.000Z" },
+        [pubkey2]: { name: "Device 2", createdAt: "2024-01-02T00:00:00.000Z" },
+      });
+
+      expect(getDeviceName(pubkey1)).toBe("Device 1");
+      expect(getDeviceName(pubkey2)).toBe("Device 2");
+    });
+  });
+
+  describe("setDeviceName", () => {
+    it("should store name correctly for new pubkey", () => {
+      const pubkey = "new-pubkey";
+      const name = "My New Device";
+
+      setDeviceName(pubkey, name);
+
+      const stored = JSON.parse(mockStorage[STORAGE_KEY]);
+      expect(stored[pubkey]).toBeDefined();
+      expect(stored[pubkey].name).toBe(name);
+      expect(stored[pubkey].createdAt).toBeDefined();
+    });
+
+    it("should create ISO timestamp when storing", () => {
+      const pubkey = "test-pubkey";
+      const name = "Test Device";
+
+      setDeviceName(pubkey, name);
+
+      const stored = JSON.parse(mockStorage[STORAGE_KEY]);
+      expect(stored[pubkey].createdAt).toMatch(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+      );
+    });
+
+    it("should update existing device name", () => {
+      const pubkey = "existing-pubkey";
+      mockStorage[STORAGE_KEY] = JSON.stringify({
+        [pubkey]: { name: "Old Name", createdAt: "2024-01-01T00:00:00.000Z" },
+      });
+
+      setDeviceName(pubkey, "New Name");
+
+      const stored = JSON.parse(mockStorage[STORAGE_KEY]);
+      expect(stored[pubkey].name).toBe("New Name");
+    });
+
+    it("should preserve other devices when adding new one", () => {
+      mockStorage[STORAGE_KEY] = JSON.stringify({
+        "existing-pubkey": { name: "Existing Device", createdAt: "2024-01-01T00:00:00.000Z" },
+      });
+
+      setDeviceName("new-pubkey", "New Device");
+
+      const stored = JSON.parse(mockStorage[STORAGE_KEY]);
+      expect(stored["existing-pubkey"].name).toBe("Existing Device");
+      expect(stored["new-pubkey"].name).toBe("New Device");
+    });
+
+    it("should handle empty string name", () => {
+      const pubkey = "test-pubkey";
+
+      setDeviceName(pubkey, "");
+
+      const stored = JSON.parse(mockStorage[STORAGE_KEY]);
+      expect(stored[pubkey].name).toBe("");
+    });
+
+    it("should handle names with special characters", () => {
+      const pubkey = "test-pubkey";
+      const name = 'My "Special" Device <test>';
+
+      setDeviceName(pubkey, name);
+
+      const stored = JSON.parse(mockStorage[STORAGE_KEY]);
+      expect(stored[pubkey].name).toBe(name);
+    });
+  });
+
+  describe("removeDeviceName", () => {
+    it("should remove entry for given pubkey", () => {
+      const pubkey = "pubkey-to-remove";
+      mockStorage[STORAGE_KEY] = JSON.stringify({
+        [pubkey]: { name: "Device", createdAt: "2024-01-01T00:00:00.000Z" },
+      });
+
+      removeDeviceName(pubkey);
+
+      const stored = JSON.parse(mockStorage[STORAGE_KEY]);
+      expect(stored[pubkey]).toBeUndefined();
+    });
+
+    it("should not throw when removing non-existent pubkey", () => {
+      mockStorage[STORAGE_KEY] = JSON.stringify({});
+
+      expect(() => removeDeviceName("non-existent")).not.toThrow();
+    });
+
+    it("should not throw when localStorage is empty", () => {
+      expect(() => removeDeviceName("any-pubkey")).not.toThrow();
+    });
+
+    it("should preserve other devices when removing one", () => {
+      mockStorage[STORAGE_KEY] = JSON.stringify({
+        "pubkey-1": { name: "Device 1", createdAt: "2024-01-01T00:00:00.000Z" },
+        "pubkey-2": { name: "Device 2", createdAt: "2024-01-02T00:00:00.000Z" },
+        "pubkey-3": { name: "Device 3", createdAt: "2024-01-03T00:00:00.000Z" },
+      });
+
+      removeDeviceName("pubkey-2");
+
+      const stored = JSON.parse(mockStorage[STORAGE_KEY]);
+      expect(stored["pubkey-1"]).toBeDefined();
+      expect(stored["pubkey-2"]).toBeUndefined();
+      expect(stored["pubkey-3"]).toBeDefined();
+    });
+  });
+
+  describe("getAllDeviceNames", () => {
+    it("should return all entries", () => {
+      const mapping = {
+        "pubkey-1": { name: "Device 1", createdAt: "2024-01-01T00:00:00.000Z" },
+        "pubkey-2": { name: "Device 2", createdAt: "2024-01-02T00:00:00.000Z" },
+      };
+      mockStorage[STORAGE_KEY] = JSON.stringify(mapping);
+
+      const result = getAllDeviceNames();
+      expect(result).toEqual(mapping);
+    });
+
+    it("should return empty object when localStorage is empty", () => {
+      const result = getAllDeviceNames();
+      expect(result).toEqual({});
+    });
+
+    it("should return empty object when localStorage contains invalid JSON", () => {
+      mockStorage[STORAGE_KEY] = "invalid-json";
+
+      const result = getAllDeviceNames();
+      expect(result).toEqual({});
+    });
+
+    it("should return entries with correct structure", () => {
+      mockStorage[STORAGE_KEY] = JSON.stringify({
+        "pubkey-1": { name: "Device 1", createdAt: "2024-01-01T00:00:00.000Z" },
+      });
+
+      const result = getAllDeviceNames();
+      expect(result["pubkey-1"]).toHaveProperty("name");
+      expect(result["pubkey-1"]).toHaveProperty("createdAt");
+    });
+
+    it("should return a new object, not the same reference", () => {
+      mockStorage[STORAGE_KEY] = JSON.stringify({
+        "pubkey-1": { name: "Device 1", createdAt: "2024-01-01T00:00:00.000Z" },
+      });
+
+      const result1 = getAllDeviceNames();
+      const result2 = getAllDeviceNames();
+      expect(result1).not.toBe(result2);
+      expect(result1).toEqual(result2);
+    });
+  });
+
+  describe("integration", () => {
+    it("should set and get device name correctly", () => {
+      const pubkey = "test-pubkey";
+      const name = "Test Device";
+
+      setDeviceName(pubkey, name);
+      const result = getDeviceName(pubkey);
+
+      expect(result).toBe(name);
+    });
+
+    it("should set, get, and remove device name correctly", () => {
+      const pubkey = "test-pubkey";
+      const name = "Test Device";
+
+      setDeviceName(pubkey, name);
+      expect(getDeviceName(pubkey)).toBe(name);
+
+      removeDeviceName(pubkey);
+      expect(getDeviceName(pubkey)).toBeNull();
+    });
+
+    it("should handle multiple operations correctly", () => {
+      setDeviceName("pubkey-1", "Device 1");
+      setDeviceName("pubkey-2", "Device 2");
+      setDeviceName("pubkey-3", "Device 3");
+
+      expect(Object.keys(getAllDeviceNames())).toHaveLength(3);
+
+      removeDeviceName("pubkey-2");
+      expect(Object.keys(getAllDeviceNames())).toHaveLength(2);
+
+      setDeviceName("pubkey-1", "Updated Device 1");
+      expect(getDeviceName("pubkey-1")).toBe("Updated Device 1");
+    });
+  });
+});

--- a/src/utils/__tests__/wireguardKeys.test.ts
+++ b/src/utils/__tests__/wireguardKeys.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+
+describe("wireguardKeys utilities", () => {
+  // Store original crypto reference
+  const originalCrypto = global.crypto;
+
+  // Helper to reset the module cache
+  const resetModule = async () => {
+    vi.resetModules();
+    const module = await import("../wireguardKeys");
+    return module;
+  };
+
+  // Helper to create a mock JWK with a base64url-encoded 'd' parameter
+  const createMockJwk = (privateKeyBytes: Uint8Array) => {
+    // Convert bytes to base64url (JWK uses base64url, not standard base64)
+    const base64 = btoa(String.fromCharCode(...privateKeyBytes));
+    const base64url = base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+    return {
+      kty: "OKP",
+      crv: "X25519",
+      d: base64url,
+      x: "mockPublicKeyX",
+    };
+  };
+
+  afterEach(() => {
+    vi.resetAllMocks();
+    // Restore original crypto
+    global.crypto = originalCrypto;
+  });
+
+  describe("generateWireGuardKeypair", () => {
+    it("should generate a keypair with base64-encoded public and private keys", async () => {
+      // Create mock 32-byte keys
+      const mockPublicKeyBytes = new Uint8Array(32).fill(1);
+      const mockPrivateKeyBytes = new Uint8Array(32).fill(2);
+
+      const mockKeyPair = {
+        publicKey: { type: "public" },
+        privateKey: { type: "private" },
+      };
+
+      // Mock crypto.subtle
+      const mockSubtle = {
+        generateKey: vi.fn().mockResolvedValue(mockKeyPair),
+        exportKey: vi.fn().mockImplementation((format, key) => {
+          if (format === "raw" && key.type === "public") {
+            return Promise.resolve(mockPublicKeyBytes.buffer);
+          }
+          if (format === "jwk" && key.type === "private") {
+            return Promise.resolve(createMockJwk(mockPrivateKeyBytes));
+          }
+          throw new Error("Unknown export format");
+        }),
+      };
+
+      vi.stubGlobal("crypto", {
+        subtle: mockSubtle,
+      });
+
+      const { generateWireGuardKeypair } = await resetModule();
+      const keypair = await generateWireGuardKeypair();
+
+      expect(keypair).toBeDefined();
+      expect(keypair.publicKey).toBeDefined();
+      expect(keypair.privateKey).toBeDefined();
+      expect(typeof keypair.publicKey).toBe("string");
+      expect(typeof keypair.privateKey).toBe("string");
+    });
+
+    it("should return keys with correct base64 length for 32-byte keys", async () => {
+      // 32 bytes base64-encoded = 44 characters (with padding)
+      const mockPublicKeyBytes = new Uint8Array(32).fill(0xab);
+      const mockPrivateKeyBytes = new Uint8Array(32).fill(0xcd);
+
+      const mockKeyPair = {
+        publicKey: { type: "public" },
+        privateKey: { type: "private" },
+      };
+
+      const mockSubtle = {
+        generateKey: vi.fn().mockResolvedValue(mockKeyPair),
+        exportKey: vi.fn().mockImplementation((format, key) => {
+          if (format === "raw" && key.type === "public") {
+            return Promise.resolve(mockPublicKeyBytes.buffer);
+          }
+          if (format === "jwk" && key.type === "private") {
+            return Promise.resolve(createMockJwk(mockPrivateKeyBytes));
+          }
+          throw new Error("Unknown export format");
+        }),
+      };
+
+      vi.stubGlobal("crypto", {
+        subtle: mockSubtle,
+      });
+
+      const { generateWireGuardKeypair } = await resetModule();
+      const keypair = await generateWireGuardKeypair();
+
+      // Base64 encoding of 32 bytes produces 44 characters (32 * 4 / 3 = 42.67, rounded up with padding = 44)
+      expect(keypair.publicKey.length).toBe(44);
+      // Private key from JWK may have slightly different length due to base64url conversion
+      // but should be close to 44 characters
+      expect(keypair.privateKey.length).toBeGreaterThanOrEqual(43);
+      expect(keypair.privateKey.length).toBeLessThanOrEqual(44);
+    });
+
+    it("should call crypto.subtle.generateKey with X25519 algorithm", async () => {
+      const mockKeyPair = {
+        publicKey: { type: "public" },
+        privateKey: { type: "private" },
+      };
+
+      const mockSubtle = {
+        generateKey: vi.fn().mockResolvedValue(mockKeyPair),
+        exportKey: vi.fn().mockImplementation((format: string) => {
+          if (format === "raw") {
+            return Promise.resolve(new Uint8Array(32).buffer);
+          }
+          if (format === "jwk") {
+            return Promise.resolve(createMockJwk(new Uint8Array(32)));
+          }
+          throw new Error("Unknown export format");
+        }),
+      };
+
+      vi.stubGlobal("crypto", {
+        subtle: mockSubtle,
+      });
+
+      const { generateWireGuardKeypair } = await resetModule();
+      await generateWireGuardKeypair();
+
+      expect(mockSubtle.generateKey).toHaveBeenCalledWith(
+        { name: "X25519" },
+        true,
+        ["deriveBits"],
+      );
+    });
+
+    it("should throw error when WebCrypto API is not available", async () => {
+      vi.stubGlobal("crypto", undefined);
+
+      const { generateWireGuardKeypair } = await resetModule();
+
+      await expect(generateWireGuardKeypair()).rejects.toThrow(
+        "WebCrypto API is not available",
+      );
+    });
+
+    it("should throw error when crypto.subtle is not available", async () => {
+      vi.stubGlobal("crypto", {
+        subtle: undefined,
+      });
+
+      const { generateWireGuardKeypair } = await resetModule();
+
+      await expect(generateWireGuardKeypair()).rejects.toThrow(
+        "WebCrypto API is not available",
+      );
+    });
+
+    it("should export public key in raw format", async () => {
+      const mockKeyPair = {
+        publicKey: { type: "public" },
+        privateKey: { type: "private" },
+      };
+
+      const mockSubtle = {
+        generateKey: vi.fn().mockResolvedValue(mockKeyPair),
+        exportKey: vi.fn().mockImplementation((format) => {
+          if (format === "raw") {
+            return Promise.resolve(new Uint8Array(32).buffer);
+          }
+          if (format === "jwk") {
+            return Promise.resolve(createMockJwk(new Uint8Array(32)));
+          }
+          throw new Error("Unknown export format");
+        }),
+      };
+
+      vi.stubGlobal("crypto", {
+        subtle: mockSubtle,
+      });
+
+      const { generateWireGuardKeypair } = await resetModule();
+      await generateWireGuardKeypair();
+
+      expect(mockSubtle.exportKey).toHaveBeenCalledWith(
+        "raw",
+        mockKeyPair.publicKey,
+      );
+    });
+
+    it("should export private key in jwk format", async () => {
+      const mockKeyPair = {
+        publicKey: { type: "public" },
+        privateKey: { type: "private" },
+      };
+
+      const mockSubtle = {
+        generateKey: vi.fn().mockResolvedValue(mockKeyPair),
+        exportKey: vi.fn().mockImplementation((format) => {
+          if (format === "raw") {
+            return Promise.resolve(new Uint8Array(32).buffer);
+          }
+          if (format === "jwk") {
+            return Promise.resolve(createMockJwk(new Uint8Array(32)));
+          }
+          throw new Error("Unknown export format");
+        }),
+      };
+
+      vi.stubGlobal("crypto", {
+        subtle: mockSubtle,
+      });
+
+      const { generateWireGuardKeypair } = await resetModule();
+      await generateWireGuardKeypair();
+
+      expect(mockSubtle.exportKey).toHaveBeenCalledWith(
+        "jwk",
+        mockKeyPair.privateKey,
+      );
+    });
+
+    it("should generate different keypairs on subsequent calls", async () => {
+      let callCount = 0;
+      const mockSubtle = {
+        generateKey: vi.fn().mockImplementation(() => {
+          callCount++;
+          return Promise.resolve({
+            publicKey: { type: "public", id: callCount },
+            privateKey: { type: "private", id: callCount },
+          });
+        }),
+        exportKey: vi.fn().mockImplementation((format, key) => {
+          if (format === "raw") {
+            // Return different bytes based on key id
+            const bytes = new Uint8Array(32);
+            bytes.fill(key.id);
+            return Promise.resolve(bytes.buffer);
+          }
+          if (format === "jwk") {
+            // Return different JWK based on key id
+            const bytes = new Uint8Array(32);
+            bytes.fill(key.id + 100);
+            return Promise.resolve(createMockJwk(bytes));
+          }
+          throw new Error("Unknown export format");
+        }),
+      };
+
+      vi.stubGlobal("crypto", {
+        subtle: mockSubtle,
+      });
+
+      const { generateWireGuardKeypair } = await resetModule();
+      const keypair1 = await generateWireGuardKeypair();
+      const keypair2 = await generateWireGuardKeypair();
+
+      expect(keypair1.publicKey).not.toBe(keypair2.publicKey);
+      expect(keypair1.privateKey).not.toBe(keypair2.privateKey);
+    });
+
+    it("should propagate errors from crypto.subtle.generateKey", async () => {
+      const mockSubtle = {
+        generateKey: vi.fn().mockRejectedValue(new Error("Key generation failed")),
+        exportKey: vi.fn(),
+      };
+
+      vi.stubGlobal("crypto", {
+        subtle: mockSubtle,
+      });
+
+      const { generateWireGuardKeypair } = await resetModule();
+
+      await expect(generateWireGuardKeypair()).rejects.toThrow(
+        "Key generation failed",
+      );
+    });
+  });
+});

--- a/src/utils/deviceDetection.ts
+++ b/src/utils/deviceDetection.ts
@@ -1,0 +1,128 @@
+/**
+ * Device detection utilities for determining device type and providing
+ * appropriate naming suggestions for WireGuard peer configurations.
+ */
+
+export type DeviceType =
+  | "iphone"
+  | "ipad"
+  | "mac"
+  | "windows"
+  | "android"
+  | "linux"
+  | "unknown";
+
+/**
+ * Detect the current device type based on user agent and platform
+ */
+export function detectDeviceTypeRaw(): DeviceType {
+  if (typeof navigator === "undefined") return "unknown";
+
+  const ua = navigator.userAgent;
+  const platform = navigator.platform || "";
+
+  // iOS detection
+  if (/iPhone/.test(ua)) return "iphone";
+  if (/iPad/.test(ua)) return "ipad";
+  // iPadOS 13+ reports desktop Safari UA but has touch capability
+  if (/Macintosh/.test(ua) && navigator.maxTouchPoints > 1) return "ipad";
+
+  // macOS detection
+  if (/Macintosh|MacIntel|MacPPC|Mac68K/.test(platform)) return "mac";
+  if (/Mac OS X/.test(ua)) return "mac";
+
+  // Windows detection
+  if (/Win32|Win64|Windows|WinCE/.test(platform)) return "windows";
+  if (/Windows/.test(ua)) return "windows";
+
+  // Android detection
+  if (/Android/.test(ua)) return "android";
+
+  // Linux detection (must come after Android since Android is Linux-based)
+  if (/Linux/.test(platform)) return "linux";
+  if (/Linux/.test(ua) && !/Android/.test(ua)) return "linux";
+
+  return "unknown";
+}
+
+/**
+ * Get a human-readable device name suggestion based on detected device type
+ */
+export function detectDeviceType(): string {
+  const deviceType = detectDeviceTypeRaw();
+
+  switch (deviceType) {
+    case "iphone":
+      return "iPhone";
+    case "ipad":
+      return "iPad";
+    case "mac":
+      return "MacBook";
+    case "windows":
+      return "Windows PC";
+    case "android":
+      return "Android Phone";
+    case "linux":
+      return "Linux Desktop";
+    default:
+      return "Device";
+  }
+}
+
+/**
+ * Get an emoji icon representing the detected device type
+ */
+export function getDeviceIcon(): string {
+  const deviceType = detectDeviceTypeRaw();
+
+  switch (deviceType) {
+    case "iphone":
+    case "android":
+      return "\u{1F4F1}"; // mobile phone emoji
+    case "ipad":
+      return "\u{1F4F2}"; // tablet emoji (mobile phone with arrow)
+    case "mac":
+    case "windows":
+    case "linux":
+      return "\u{1F4BB}"; // laptop emoji
+    default:
+      return "\u{1F5A5}"; // desktop computer emoji
+  }
+}
+
+/**
+ * Infer device type from a device name string (case-insensitive matching)
+ */
+export function inferDeviceTypeFromName(name: string): DeviceType {
+  const lowerName = name.toLowerCase();
+
+  if (lowerName.includes("iphone")) return "iphone";
+  if (lowerName.includes("ipad")) return "ipad";
+  if (lowerName.includes("mac") || lowerName.includes("macbook")) return "mac";
+  if (lowerName.includes("windows") || lowerName.includes("pc")) return "windows";
+  if (lowerName.includes("android")) return "android";
+  if (lowerName.includes("linux") || lowerName.includes("ubuntu") || lowerName.includes("debian")) return "linux";
+
+  return "unknown";
+}
+
+/**
+ * Get an emoji icon based on a device name string
+ */
+export function getDeviceIconFromName(name: string): string {
+  const deviceType = inferDeviceTypeFromName(name);
+
+  switch (deviceType) {
+    case "iphone":
+    case "android":
+      return "\u{1F4F1}"; // mobile phone emoji
+    case "ipad":
+      return "\u{1F4F2}"; // tablet emoji (mobile phone with arrow)
+    case "mac":
+    case "windows":
+    case "linux":
+      return "\u{1F4BB}"; // laptop emoji
+    default:
+      return "\u{1F5A5}"; // desktop computer emoji
+  }
+}

--- a/src/utils/deviceNames.ts
+++ b/src/utils/deviceNames.ts
@@ -1,0 +1,92 @@
+/**
+ * Device name management utilities for WireGuard peers.
+ * Stores user-defined device names in localStorage, keyed by public key.
+ */
+
+export interface DeviceNameEntry {
+  name: string;
+  createdAt: string; // ISO timestamp
+}
+
+export interface DeviceNameMapping {
+  [pubkey: string]: DeviceNameEntry;
+}
+
+const STORAGE_KEY = "wg-device-names";
+
+/**
+ * Get the stored device name for a given public key
+ *
+ * @param pubkey - Base64-encoded WireGuard public key
+ * @returns The stored device name, or null if not found
+ */
+export function getDeviceName(pubkey: string): string | null {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) return null;
+
+    const mapping: DeviceNameMapping = JSON.parse(stored);
+    return mapping[pubkey]?.name ?? null;
+  } catch (error) {
+    console.error("Failed to get device name:", error);
+    return null;
+  }
+}
+
+/**
+ * Store a device name for a given public key
+ *
+ * @param pubkey - Base64-encoded WireGuard public key
+ * @param name - User-defined device name
+ */
+export function setDeviceName(pubkey: string, name: string): void {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    const mapping: DeviceNameMapping = stored ? JSON.parse(stored) : {};
+
+    mapping[pubkey] = {
+      name,
+      createdAt: mapping[pubkey]?.createdAt ?? new Date().toISOString(),
+    };
+
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(mapping));
+  } catch (error) {
+    console.error("Failed to set device name:", error);
+  }
+}
+
+/**
+ * Remove the stored device name for a given public key
+ *
+ * @param pubkey - Base64-encoded WireGuard public key
+ */
+export function removeDeviceName(pubkey: string): void {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) return;
+
+    const mapping: DeviceNameMapping = JSON.parse(stored);
+    delete mapping[pubkey];
+
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(mapping));
+  } catch (error) {
+    console.error("Failed to remove device name:", error);
+  }
+}
+
+/**
+ * Get all stored device name mappings
+ *
+ * @returns Object mapping public keys to device name entries
+ */
+export function getAllDeviceNames(): DeviceNameMapping {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) return {};
+
+    return JSON.parse(stored);
+  } catch (error) {
+    console.error("Failed to get all device names:", error);
+    return {};
+  }
+}

--- a/src/utils/wireguardKeys.ts
+++ b/src/utils/wireguardKeys.ts
@@ -1,0 +1,44 @@
+/**
+ * WireGuard key generation utilities using WebCrypto API.
+ * Generates X25519 keypairs for WireGuard peer configurations.
+ */
+
+export interface WireGuardKeypair {
+  publicKey: string; // Base64-encoded 32-byte X25519 public key
+  privateKey: string; // Base64-encoded 32-byte X25519 private key
+}
+
+/**
+ * Generate a new WireGuard X25519 keypair using WebCrypto API.
+ *
+ * @returns Promise resolving to an object containing base64-encoded public and private keys
+ * @throws Error if WebCrypto API is not available or key generation fails
+ */
+export async function generateWireGuardKeypair(): Promise<WireGuardKeypair> {
+  if (typeof crypto === "undefined" || !crypto.subtle) {
+    throw new Error("WebCrypto API is not available");
+  }
+
+  // Generate X25519 keypair
+  const keyPair = (await crypto.subtle.generateKey(
+    { name: "X25519" },
+    true, // extractable - needed to export the keys
+    ["deriveBits"],
+  )) as CryptoKeyPair;
+
+  // Export public key (raw format gives us the 32-byte key directly)
+  const publicKeyRaw = await crypto.subtle.exportKey("raw", keyPair.publicKey);
+  const publicKey = btoa(
+    String.fromCharCode(...new Uint8Array(publicKeyRaw)),
+  );
+
+  // Export private key using JWK format (more robust than PKCS8 slicing)
+  const jwk = await crypto.subtle.exportKey("jwk", keyPair.privateKey);
+  // JWK 'd' parameter is the private key in base64url encoding
+  // Convert base64url to standard base64 and add padding
+  const base64url = jwk.d!.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = (4 - (base64url.length % 4)) % 4;
+  const privateKey = base64url + "=".repeat(padding);
+
+  return { publicKey, privateKey };
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,16 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  /** Backend API URL (defaults to https://preprod-api.b7s.services) */
+  readonly VITE_API_URL: string;
+  /** Cardano network: 'mainnet' | 'preprod' | 'preview' (defaults to preprod) */
+  readonly VITE_CARDANO_NETWORK: 'mainnet' | 'preprod' | 'preview';
+  /** WireGuard feature flag - set to 'true' to enable WireGuard UI */
+  readonly VITE_WIREGUARD_ENABLED: string;
+  /** OpenVPN region identifier(s) - comma-separated list. If not set, OpenVPN flows are hidden */
+  readonly VITE_OPENVPN_REGION: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds WireGuard VPN support end-to-end with a protocol toggle, device registration/config delivery, and device list management. Updates docs and install guide for WireGuard and OpenVPN.

- **New Features**
  - Feature-flagged WireGuard UI (VITE_WIREGUARD_ENABLED) with optional OpenVPN link (VITE_OPENVPN_REGION).
  - WireGuard API hooks: register, fetch profile (text/plain), delete peer, list devices.
  - DeviceConfigModal for naming, key generation, and QR/download/copy of config.
  - WireGuardDeviceList integrated into VpnInstance; improved region display.
  - Utilities for device detection, device name storage, and X25519 key generation.
  - Comprehensive tests for hooks, components, and utilities; new WireGuard types.

- **Migration**
  - Set VITE_WIREGUARD_ENABLED=true in .env; optionally set VITE_OPENVPN_REGION for OpenVPN.
  - Backend must support /client/wg-register, /client/wg-profile (returns text/plain), /client/wg-delete, /client/wg-devices.
  - Use postPlainText for WireGuard profile responses.

<sup>Written for commit f5ce26a7d33b0cf9d7cc29058a70bf6b744619e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WireGuard support: protocol toggle, device management (add/delete/regenerate), and device config delivery (QR, download, copy)
  * Protocol-aware region selection and per-instance device listings

* **Documentation**
  * Updated install guides, FAQs, and "How It Works" with protocol-specific content and setup instructions
  * Added environment example for frontend feature flags

* **Improvements**
  * Account/purchase flows updated for protocol & region selection

* **Tests**
  * Comprehensive unit tests for WireGuard flows, UI components, and utilities

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->