### PR TITLE
fix(faq): clarify use of multiple devices

### DIFF
--- a/src/pages/DocsFaqs.tsx
+++ b/src/pages/DocsFaqs.tsx
@@ -291,7 +291,7 @@ const DocsFaqs = () => {
         id: "multiple-instances-ovpn",
         question: "Can I buy multiple VPN subscriptions?",
         answer:
-          "Yes, you can purchase multiple subscriptions for different regions or to support more concurrent connections.",
+          "Yes, you can purchase multiple subscriptions. Each OpenVPN subscription supports one concurrent connection, but you can have multiple subscriptions if you need simultaneous connections on multiple devices.",
         openVpnOnly: true,
       },
       // IP logging - protocol aware


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarified the OpenVPN FAQ about using multiple devices. Each subscription allows one concurrent connection; users can buy multiple subscriptions for simultaneous connections.

<sup>Written for commit e1117d4f6c698c343f3ca630d27e154021c9b629. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

