### PR TITLE
fix: pass protocol to backend

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -31,6 +31,7 @@ export interface TxSignupRequest {
   duration: number;
   price: number;
   region: string;
+  protocol: VpnProtocol;
 }
 
 export interface TxSignupResponse {
@@ -73,6 +74,7 @@ export interface TxRenewRequest {
   duration: number;
   price: number;
   region: string;
+  protocol: VpnProtocol;
 }
 
 export interface TxRenewResponse {

--- a/src/components/RegionSelect.tsx
+++ b/src/components/RegionSelect.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import Select from "react-select";
-import type { VpnProtocolType } from "./ProtocolToggle";
+import type { VpnProtocol } from "../api/types";
+import { shouldShowWireGuardUI, type VpnProtocolType } from "./ProtocolToggle";
 
 /**
  * Map of region IDs to friendly display names.
@@ -49,6 +50,16 @@ const openVpnRegions = openVpnRegionsEnv
  */
 function isOpenVpnRegion(region: string): boolean {
   return openVpnRegions.includes(region);
+}
+
+/**
+ * Determine the protocol for a given region.
+ * - When the WireGuard UI is disabled, all regions are treated as OpenVPN.
+ * - Otherwise, regions listed in VITE_OPENVPN_REGION are OpenVPN; everything else is WireGuard.
+ */
+export function getProtocolForRegion(region: string): VpnProtocol {
+  if (!shouldShowWireGuardUI()) return "openvpn";
+  return isOpenVpnRegion(region) ? "openvpn" : "wireguard";
 }
 
 /**

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -21,7 +21,10 @@ import ProtocolToggle, {
   isOpenVpnAvailable,
   type VpnProtocolType,
 } from "../components/ProtocolToggle";
-import RegionSelect, { filterRegionsByProtocol } from "../components/RegionSelect";
+import RegionSelect, {
+  filterRegionsByProtocol,
+  getProtocolForRegion,
+} from "../components/RegionSelect";
 import {
   getPendingTransactions,
   addPendingTransaction,
@@ -348,6 +351,7 @@ const Account = () => {
         duration: targetDuration,
         price: option.price,
         region: payloadRegion,
+        protocol: getProtocolForRegion(payloadRegion),
       };
 
       const data = await signupMutation.mutateAsync(payload);
@@ -491,6 +495,7 @@ const Account = () => {
         duration: selectedRenewDuration,
         price: renewOption.price,
         region: payloadRegion,
+        protocol: getProtocolForRegion(payloadRegion),
       });
 
       const newExpirationDate =
@@ -561,6 +566,7 @@ const Account = () => {
           return {
             id: client.id,
             region: client.region,
+            protocol: getProtocolForRegion(client.region),
             duration: formatDuration(normalizedDurationMs),
             status: isActive ? ("Active" as const) : ("Expired" as const),
             expires: formatTimeRemaining(client.expiration),
@@ -579,6 +585,7 @@ const Account = () => {
       .map((pending) => ({
         id: pending.id,
         region: pending.region,
+        protocol: getProtocolForRegion(pending.region),
         duration: formatDuration(pending.duration),
         status: "Pending" as const,
         expires: "Setting up...",
@@ -978,6 +985,7 @@ const Account = () => {
                     <VpnInstance
                       key={instance.id}
                       region={instance.region}
+                      protocol={instance.protocol}
                       status={instance.status}
                       expires={instance.expires}
                       shouldSpinRenew={areAllInstancesExpired}

--- a/src/utils/instanceSort.ts
+++ b/src/utils/instanceSort.ts
@@ -1,3 +1,5 @@
+import type { VpnProtocol } from "../api/types";
+
 export type SortOption =
   | "default"
   | "recently_expired"
@@ -7,6 +9,7 @@ export type SortOption =
 export interface VpnInstanceData {
   id: string;
   region: string;
+  protocol: VpnProtocol;
   duration: string;
   status: "Active" | "Expired" | "Pending";
   expires: string;


### PR DESCRIPTION
Closes #261 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send the correct VPN protocol to the backend for each instance based on region and whether the WireGuard UI is enabled, and include it in signup/renew API requests. This addresses #261 by preventing protocol mismatches during creation and renewal.

- **Bug Fixes**
  - Added `getProtocolForRegion` in `RegionSelect` to resolve `openvpn` vs `wireguard` using `VITE_OPENVPN_REGION` and `shouldShowWireGuardUI` (fallback to `openvpn` when WireGuard UI is off).
  - Include `protocol` in signup/renew payloads via `TxSignupRequest` and `TxRenewRequest`.
  - Surface `protocol` across the UI: attach to active/pending instances, pass to `VpnInstance`, and extend `VpnInstanceData` for consistent sorting/rendering.

<sup>Written for commit a0913db9229f0f42ed031be9bf2ae90554f12025. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/vpn-frontend/pull/262?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced VPN instance handling to properly track and assign protocols based on region selection, enabling the application to accurately render protocol-specific behavior for each instance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->