### PR TITLE
fix: modify signup flow to account for Wireguard

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -142,6 +142,56 @@ export function getClientList(
   return post<ClientInfo[]>("/client/list", request);
 }
 
+/**
+ * Variant of getClientList that treats 404 as "no clients yet" rather than
+ * an error. Used by the WireGuard polling path so a first-time signup can
+ * keep waiting for the new client to surface without burning attempts.
+ */
+export async function getClientListWithGraceful404(
+  request: ClientListRequest,
+): Promise<ClientInfo[]> {
+  const url = `${API_BASE_URL}/client/list`;
+
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        accept: "application/json",
+      },
+      body: JSON.stringify(request),
+    });
+
+    if (response.status === 404) {
+      return [];
+    }
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        `API Error: ${response.status} ${response.statusText}${errorText ? ` - ${errorText}` : ""}`,
+      );
+    }
+
+    const contentType = response.headers.get("content-type") || "";
+    if (contentType.includes("application/json")) {
+      return response.json() as Promise<ClientInfo[]>;
+    }
+
+    const text = await response.text();
+    try {
+      return JSON.parse(text) as ClientInfo[];
+    } catch {
+      return [];
+    }
+  } catch (error) {
+    if (error instanceof TypeError) {
+      throw new Error("Network error: Unable to connect to the API");
+    }
+    throw error;
+  }
+}
+
 // Types moved to types.ts to avoid conflicts
 
 export function checkClientAvailable(

--- a/src/api/hooks/useClientPolling.ts
+++ b/src/api/hooks/useClientPolling.ts
@@ -1,17 +1,23 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { checkClientAvailableWithGraceful404 } from "../client";
+import {
+  checkClientAvailableWithGraceful404,
+  getClientListWithGraceful404,
+} from "../client";
 import {
   updateTransactionStatus,
   updateTransactionAttempts,
   getActivePendingTransactions,
 } from "../../utils/pendingTransactions";
+import { useWalletStore } from "../../stores/walletStore";
+import type { VpnProtocol } from "../types";
 
 interface PollingState {
   isPolling: boolean;
   clientId: string | null;
   attempts: number;
   maxAttempts: number;
+  protocol: VpnProtocol;
 }
 
 const DEFAULT_MAX_ATTEMPTS = 20;
@@ -27,6 +33,7 @@ export function useClientPolling() {
         clientId: firstPending.id,
         attempts: firstPending.attempts,
         maxAttempts: DEFAULT_MAX_ATTEMPTS,
+        protocol: firstPending.protocol,
       };
     }
 
@@ -35,6 +42,7 @@ export function useClientPolling() {
       clientId: null,
       attempts: 0,
       maxAttempts: DEFAULT_MAX_ATTEMPTS,
+      protocol: "openvpn",
     };
   });
 
@@ -42,12 +50,17 @@ export function useClientPolling() {
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
 
   const startPolling = useCallback(
-    (clientId: string, initialAttempts: number = 0) => {
+    (
+      clientId: string,
+      protocol: VpnProtocol,
+      initialAttempts: number = 0,
+    ) => {
       setPollingState({
         isPolling: true,
         clientId,
         attempts: initialAttempts,
         maxAttempts: DEFAULT_MAX_ATTEMPTS,
+        protocol,
       });
     },
     [],
@@ -82,11 +95,29 @@ export function useClientPolling() {
 
     const pollClient = async () => {
       try {
-        const response = await checkClientAvailableWithGraceful404({
-          id: pollingState.clientId!,
-        });
+        let isReady = false;
 
-        if (response !== null) {
+        if (pollingState.protocol === "wireguard") {
+          // WireGuard subscriptions don't expose /client/available — they're
+          // ready as soon as the on-chain transaction confirms and the new
+          // clientId surfaces in /client/list. If the wallet isn't connected
+          // we treat this attempt as "not ready" and keep counting toward
+          // maxAttempts so the poll eventually gives up instead of stalling.
+          const ownerAddress = useWalletStore.getState().walletAddress;
+          const list = ownerAddress
+            ? await getClientListWithGraceful404({ ownerAddress })
+            : [];
+          isReady = list.some(
+            (client) => client.id === pollingState.clientId,
+          );
+        } else {
+          const response = await checkClientAvailableWithGraceful404({
+            id: pollingState.clientId!,
+          });
+          isReady = response !== null;
+        }
+
+        if (isReady) {
           stopPolling(true);
 
           await queryClient.invalidateQueries({ queryKey: ["clientList"] });
@@ -157,6 +188,7 @@ export function useClientPolling() {
     pollingState.clientId,
     pollingState.attempts,
     pollingState.maxAttempts,
+    pollingState.protocol,
     queryClient,
     stopPolling,
   ]);

--- a/src/components/DeviceConfigModal.tsx
+++ b/src/components/DeviceConfigModal.tsx
@@ -2,8 +2,12 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { QRCodeSVG } from 'qrcode.react';
 import { detectDeviceType } from '../utils/deviceDetection';
 import { generateWireGuardKeypair } from '../utils/wireguardKeys';
-import { setDeviceName } from '../utils/deviceNames';
-import { useWireGuardProfile } from '../api/hooks/useWireGuard';
+import { setDeviceName, removeDeviceName } from '../utils/deviceNames';
+import {
+  useWireGuardDeletePeer,
+  useWireGuardProfile,
+  useWireGuardRegister,
+} from '../api/hooks/useWireGuard';
 import { useWalletStore } from '../stores/walletStore';
 import type { WireGuardDevice } from '../api/types';
 
@@ -66,10 +70,17 @@ export function DeviceConfigModal({
   const inputRef = useRef<HTMLInputElement>(null);
   const copiedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const copyErrorTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Last unix timestamp (in seconds) we minted for a WireGuard auth payload.
+  // Bumped monotonically so back-to-back signs in the same wall second don't
+  // produce identical (client_id, timestamp, signature) triples — Ed25519
+  // signatures are deterministic and the backend rejects replays.
+  const lastAuthTimestampRef = useRef(0);
 
   // Hooks
   const { signMessage } = useWalletStore();
+  const wireGuardRegister = useWireGuardRegister();
   const wireGuardProfile = useWireGuardProfile();
+  const wireGuardDeletePeer = useWireGuardDeletePeer();
 
   const headingId = 'device-config-heading';
 
@@ -204,34 +215,77 @@ export function DeviceConfigModal({
     setGenerationError(null);
 
     try {
-      // Step 1: Generate keypair
+      // Step 1: Generate a fresh X25519 keypair. Re-download regenerates
+      // because we never persist the private key.
       const newKeypair = await generateWireGuardKeypair();
 
-      // Step 2: Create auth payload and get config
-      const timestamp = Math.floor(Date.now() / 1000);
-      const challenge = `${clientId}${timestamp}`;
+      // Each WireGuard endpoint takes a fresh COSE auth payload — the
+      // backend treats every (client_id, timestamp, signature) triple as
+      // one-shot, so we sign per call. Timestamp is bumped monotonically
+      // to avoid collisions when several calls land in the same second.
+      const buildAuth = async () => {
+        const now = Math.floor(Date.now() / 1000);
+        const timestamp = Math.max(now, lastAuthTimestampRef.current + 1);
+        lastAuthTimestampRef.current = timestamp;
+        const challenge = `${clientId}${timestamp}`;
+        const signResult = (await signMessage(challenge)) as SignDataResponse;
+        return {
+          client_id: clientId,
+          timestamp,
+          signature: signResult.signature,
+          key: signResult.key,
+        };
+      };
 
-      const signResult = (await signMessage(challenge)) as SignDataResponse;
-
-      const configText = await wireGuardProfile.mutateAsync({
-        client_id: clientId,
-        timestamp,
-        signature: signResult.signature,
-        key: signResult.key,
+      // Step 2: Register the new pubkey. /wg-profile returns 404 if the
+      // pubkey isn't registered, so this must come first.
+      // Note: for re-download we register BEFORE deleting the old peer so
+      // a downstream failure can't leave the user with no device. The
+      // trade-off is that an at-limit re-download will fail with "device
+      // limit reached" and the user will need to use Regenerate All.
+      const registerAuth = await buildAuth();
+      await wireGuardRegister.mutateAsync({
+        ...registerAuth,
         wg_pubkey: newKeypair.publicKey,
       });
 
-      // Step 3: Replace private key placeholder
+      // Step 3: Fetch the config text for the newly-registered pubkey.
+      const profileAuth = await buildAuth();
+      const configText = await wireGuardProfile.mutateAsync({
+        ...profileAuth,
+        wg_pubkey: newKeypair.publicKey,
+      });
+
+      // Step 4: Re-download only — retire the old peer now that the
+      // replacement is in place. If this fails, the user has a working
+      // new device plus an orphan they can clean up via Regenerate All.
+      if (existingDevice) {
+        try {
+          const deleteAuth = await buildAuth();
+          await wireGuardDeletePeer.mutateAsync({
+            ...deleteAuth,
+            wg_pubkey: existingDevice.pubkey,
+          });
+          removeDeviceName(existingDevice.pubkey);
+        } catch (deleteError) {
+          console.warn(
+            'Failed to remove old peer after re-download; new device is active but old entry remains:',
+            deleteError,
+          );
+        }
+      }
+
+      // Step 5: Replace private key placeholder
       const finalConfig = configText.replace(
         PRIVATE_KEY_PLACEHOLDER,
         newKeypair.privateKey
       );
       setConfig(finalConfig);
 
-      // Step 4: Store device name locally
+      // Step 6: Store device name locally
       setDeviceName(newKeypair.publicKey, finalName);
 
-      // Step 5: Notify parent of new device
+      // Step 7: Notify parent of new device
       if (onDeviceCreated && !existingDevice) {
         const newDevice: WireGuardDevice = {
           pubkey: newKeypair.publicKey,
@@ -254,7 +308,7 @@ export function DeviceConfigModal({
     } finally {
       setIsGenerating(false);
     }
-  }, [deviceName, existingDevice, clientId, signMessage, wireGuardProfile, onDeviceCreated]);
+  }, [deviceName, existingDevice, clientId, signMessage, wireGuardRegister, wireGuardProfile, wireGuardDeletePeer, onDeviceCreated]);
 
   const handleNameSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/components/RegionSelect.tsx
+++ b/src/components/RegionSelect.tsx
@@ -28,7 +28,7 @@ const REGION_FRIENDLY_NAMES: Record<string, string> = {
  * Get the friendly display name for a region.
  * Returns "Friendly Name (technical-id)" format.
  */
-function getRegionDisplayName(regionId: string): string {
+export function getRegionDisplayName(regionId: string): string {
   const friendlyName = REGION_FRIENDLY_NAMES[regionId];
   if (friendlyName) {
     return `${friendlyName} (${regionId})`;

--- a/src/components/VpnInstance.tsx
+++ b/src/components/VpnInstance.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import type { VpnProtocol, WireGuardDevice } from "../api/types";
 import SpinningBorderButton from "./SpinningBorderButton";
 import WireGuardDeviceList from "./WireGuardDeviceList";
@@ -10,6 +9,11 @@ interface VpnInstanceProps {
   protocol?: VpnProtocol;
   devices?: WireGuardDevice[];
   deviceLimit?: number;
+  isDevicesLoading?: boolean;
+  devicesError?: string | null;
+  isExpanded?: boolean;
+  onToggleExpand?: () => void;
+  onRetryDevices?: () => void;
   onDelete?: () => void;
   onGetConfig?: () => void;
   onStartRenew?: () => void;
@@ -62,6 +66,11 @@ const VpnInstance = ({
   protocol = "openvpn",
   devices = [],
   deviceLimit = 3,
+  isDevicesLoading = false,
+  devicesError = null,
+  isExpanded = false,
+  onToggleExpand,
+  onRetryDevices,
   onGetConfig,
   onStartRenew,
   onStartBuyTime,
@@ -77,7 +86,6 @@ const VpnInstance = ({
   onCancelRenewal,
   shouldSpinRenew = false,
 }: VpnInstanceProps) => {
-  const [isExpanded, setIsExpanded] = useState(false);
   const isWireGuard = protocol === "wireguard";
 
   const formatPrice = (priceLovelace: number) => {
@@ -86,7 +94,7 @@ const VpnInstance = ({
 
   const toggleExpand = () => {
     if (isWireGuard) {
-      setIsExpanded(!isExpanded);
+      onToggleExpand?.();
     }
   };
 
@@ -150,13 +158,30 @@ const VpnInstance = ({
       {isWireGuard && isExpanded && status === "Active" && (
         <>
           <div className="w-full border-t border-white/20 my-1" />
-          <WireGuardDeviceList
-            devices={devices}
-            deviceLimit={deviceLimit}
-            onAddDevice={onAddDevice ?? (() => {})}
-            onRedownloadConfig={onRedownloadConfig ?? (() => {})}
-            onRegenerateAll={onRegenerateAll ?? (() => {})}
-          />
+          {isDevicesLoading ? (
+            <div className="flex items-center gap-2 text-xs text-white/80 py-2">
+              <div className="w-3 h-3 border-2 border-white/60 border-t-transparent rounded-full animate-spin" />
+              Loading devices…
+            </div>
+          ) : devicesError ? (
+            <div className="flex flex-col gap-2 w-full">
+              <p className="text-xs text-red-200">{devicesError}</p>
+              <button
+                onClick={onRetryDevices}
+                className="self-start text-xs px-2.5 py-1 rounded bg-white/20 hover:bg-white/30 transition-colors cursor-pointer"
+              >
+                Retry
+              </button>
+            </div>
+          ) : (
+            <WireGuardDeviceList
+              devices={devices}
+              deviceLimit={deviceLimit}
+              onAddDevice={onAddDevice ?? (() => {})}
+              onRedownloadConfig={onRedownloadConfig ?? (() => {})}
+              onRegenerateAll={onRegenerateAll ?? (() => {})}
+            />
+          )}
           <div className="w-full border-t border-white/20 my-1" />
         </>
       )}
@@ -197,13 +222,15 @@ const VpnInstance = ({
             >
               <p className="text-black font-semibold text-xs md:text-sm">Buy Time</p>
             </SpinningBorderButton>
-            <SpinningBorderButton
-              onClick={onGetConfig}
-              className="flex items-center justify-center gap-3 py-1.5 px-3.5 backdrop-blur-xs shadow-sm bg-white text-black hover:bg-white/90 transition-all"
-              radius="8px"
-            >
-              <p className="text-black font-semibold text-xs md:text-sm">Get Config</p>
-            </SpinningBorderButton>
+            {!isWireGuard && (
+              <SpinningBorderButton
+                onClick={onGetConfig}
+                className="flex items-center justify-center gap-3 py-1.5 px-3.5 backdrop-blur-xs shadow-sm bg-white text-black hover:bg-white/90 transition-all"
+                radius="8px"
+              >
+                <p className="text-black font-semibold text-xs md:text-sm">Get Config</p>
+              </SpinningBorderButton>
+            )}
           </>
         )}
 

--- a/src/components/__tests__/DeviceConfigModal.test.tsx
+++ b/src/components/__tests__/DeviceConfigModal.test.tsx
@@ -11,11 +11,24 @@ vi.mock("../../stores/walletStore", () => ({
   }),
 }));
 
-// Mock the WireGuard profile hook
+// Mock the WireGuard hooks. The component now performs explicit register
+// (and delete-peer for re-downloads) calls before fetching the profile, so
+// each hook gets its own mock — but we route all of them through the same
+// mockMutateAsync to keep existing assertions working.
 const mockMutateAsync = vi.fn();
+const mockRegisterMutateAsync = vi.fn();
+const mockDeletePeerMutateAsync = vi.fn();
 vi.mock("../../api/hooks/useWireGuard", () => ({
   useWireGuardProfile: () => ({
     mutateAsync: mockMutateAsync,
+    isPending: false,
+  }),
+  useWireGuardRegister: () => ({
+    mutateAsync: mockRegisterMutateAsync,
+    isPending: false,
+  }),
+  useWireGuardDeletePeer: () => ({
+    mutateAsync: mockDeletePeerMutateAsync,
     isPending: false,
   }),
 }));
@@ -38,6 +51,7 @@ vi.mock("../../utils/wireguardKeys", () => ({
 vi.mock("../../utils/deviceNames", () => ({
   setDeviceName: vi.fn(),
   getDeviceName: vi.fn(),
+  removeDeviceName: vi.fn(),
 }));
 
 describe("DeviceConfigModal", () => {
@@ -58,6 +72,16 @@ describe("DeviceConfigModal", () => {
     mockMutateAsync.mockResolvedValue(
       "[Interface]\nPrivateKey = <REPLACE_WITH_YOUR_PRIVATE_KEY>\nAddress = 10.8.0.2/32\n\n[Peer]\nPublicKey = server-key\nEndpoint = vpn.example.com:51820\nAllowedIPs = 0.0.0.0/0",
     );
+    mockRegisterMutateAsync.mockResolvedValue({
+      success: true,
+      assigned_ip: "10.8.0.2",
+      device_count: 1,
+      device_limit: 3,
+    });
+    mockDeletePeerMutateAsync.mockResolvedValue({
+      success: true,
+      remaining_devices: 0,
+    });
   });
 
   afterEach(() => {

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { useWalletStore } from "../stores/walletStore";
 import {
   useRefData,
@@ -7,12 +7,18 @@ import {
   useClientProfile,
   useClientPolling,
   useRenewVpn,
+  useWireGuardDeletePeer,
 } from "../api/hooks";
 import VpnInstance from "../components/VpnInstance";
 import PurchaseCard from "../components/PurchaseCard";
 import ConfirmModal from "../components/ConfirmModal";
 import ProfileDeliveryModal from "../components/ProfileDeliveryModal";
-import type { ClientInfo } from "../api/types";
+import { DeviceConfigModal } from "../components/DeviceConfigModal";
+import type {
+  ClientInfo,
+  WireGuardDevice,
+  WireGuardDevicesResponse,
+} from "../api/types";
 import LoadingOverlay from "../components/LoadingOverlay";
 import TooltipGuide, { type TooltipStep } from "../components/TooltipGuide";
 import WalletConnection from "../components/WalletConnection";
@@ -24,7 +30,10 @@ import ProtocolToggle, {
 import RegionSelect, {
   filterRegionsByProtocol,
   getProtocolForRegion,
+  getRegionDisplayName,
 } from "../components/RegionSelect";
+import { post } from "../api/client";
+import { getDeviceName, removeDeviceName } from "../utils/deviceNames";
 import {
   getPendingTransactions,
   addPendingTransaction,
@@ -44,6 +53,7 @@ const Account = () => {
     walletAddress,
     signAndSubmitTransaction,
     setVpnConfigUrl,
+    signMessage,
   } = useWalletStore();
   const [isPurchaseLoading, setIsPurchaseLoading] = useState<boolean>(false);
   const [isConfigLoading, setIsConfigLoading] = useState<boolean>(false);
@@ -88,6 +98,27 @@ const Account = () => {
   // Region selection state - will be set once regions are loaded
   const [selectedRegion, setSelectedRegion] = useState<string>("");
 
+  // WireGuard expand/device state. Only one instance can be expanded at a
+  // time so we keep a single set of fetched devices keyed by client id.
+  const [expandedInstanceId, setExpandedInstanceId] = useState<string | null>(
+    null,
+  );
+  const [wgDevicesByClientId, setWgDevicesByClientId] = useState<
+    Record<string, { devices: WireGuardDevice[]; limit: number }>
+  >({});
+  const [wgDevicesLoadingId, setWgDevicesLoadingId] = useState<string | null>(
+    null,
+  );
+  const [wgDevicesErrorById, setWgDevicesErrorById] = useState<
+    Record<string, string | null>
+  >({});
+  const [deviceModal, setDeviceModal] = useState<{
+    clientId: string;
+    regionId: string;
+    regionName: string;
+    existingDevice?: WireGuardDevice;
+  } | null>(null);
+
   const tooltipSteps: TooltipStep[] = [
     {
       id: "duration-tooltip",
@@ -127,6 +158,160 @@ const Account = () => {
   const signupMutation = useSignup();
 
   const renewMutation = useRenewVpn();
+
+  const deletePeerMutation = useWireGuardDeletePeer();
+
+  // Build the COSE auth payload required by every WireGuard endpoint.
+  // The backend treats each (client_id, timestamp, signature) as one-shot,
+  // so we sign fresh for every call rather than caching. Timestamp is
+  // bumped monotonically per component instance so back-to-back signs in
+  // the same wall second don't produce identical triples (Ed25519 is
+  // deterministic, identical input → identical signature → server replay
+  // rejection).
+  const lastAuthTimestampRef = useRef(0);
+  const buildWireGuardAuth = useCallback(
+    async (clientId: string) => {
+      const now = Math.floor(Date.now() / 1000);
+      const timestamp = Math.max(now, lastAuthTimestampRef.current + 1);
+      lastAuthTimestampRef.current = timestamp;
+      const challenge = `${clientId}${timestamp}`;
+      const signResult = (await signMessage(challenge)) as {
+        key: string;
+        signature: string;
+      };
+      return {
+        client_id: clientId,
+        timestamp,
+        signature: signResult.signature,
+        key: signResult.key,
+      };
+    },
+    [signMessage],
+  );
+
+  const enrichDevices = useCallback(
+    (raw: WireGuardDevicesResponse["devices"]): WireGuardDevice[] =>
+      raw.map((d) => ({
+        pubkey: d.pubkey,
+        name: getDeviceName(d.pubkey) ?? "Device",
+        assignedIp: d.assigned_ip,
+        createdAt: new Date(d.created_at * 1000).toISOString(),
+      })),
+    [],
+  );
+
+  const fetchWireGuardDevices = useCallback(
+    async (clientId: string) => {
+      setWgDevicesLoadingId(clientId);
+      setWgDevicesErrorById((prev) => ({ ...prev, [clientId]: null }));
+      try {
+        const auth = await buildWireGuardAuth(clientId);
+        const response = await post<WireGuardDevicesResponse>(
+          "/client/wg-devices",
+          auth,
+        );
+        setWgDevicesByClientId((prev) => ({
+          ...prev,
+          [clientId]: {
+            devices: enrichDevices(response.devices),
+            limit: response.limit,
+          },
+        }));
+      } catch (error) {
+        console.error("Failed to fetch WireGuard devices:", error);
+        setWgDevicesErrorById((prev) => ({
+          ...prev,
+          [clientId]:
+            error instanceof Error
+              ? error.message
+              : "Failed to load devices.",
+        }));
+      } finally {
+        setWgDevicesLoadingId((prev) => (prev === clientId ? null : prev));
+      }
+    },
+    [buildWireGuardAuth, enrichDevices],
+  );
+
+  const handleToggleExpand = useCallback(
+    (clientId: string) => {
+      const willExpand = expandedInstanceId !== clientId;
+      setExpandedInstanceId(willExpand ? clientId : null);
+      if (willExpand && !wgDevicesByClientId[clientId]) {
+        // Fire-and-forget: state updates inside the helper drive the UI.
+        void fetchWireGuardDevices(clientId);
+      }
+    },
+    [expandedInstanceId, fetchWireGuardDevices, wgDevicesByClientId],
+  );
+
+  const handleDeviceCreated = useCallback(
+    (clientId: string, device: WireGuardDevice) => {
+      // Optimistic insert so the user sees their new device without a
+      // second wallet signature prompt. Real assigned_ip lands on next fetch.
+      setWgDevicesByClientId((prev) => {
+        const current = prev[clientId];
+        if (!current) return prev;
+        if (current.devices.some((d) => d.pubkey === device.pubkey)) {
+          return prev;
+        }
+        return {
+          ...prev,
+          [clientId]: {
+            ...current,
+            devices: [...current.devices, device],
+          },
+        };
+      });
+    },
+    [],
+  );
+
+  const handleRegenerateAll = useCallback(
+    async (clientId: string) => {
+      const current = wgDevicesByClientId[clientId];
+      if (!current || current.devices.length === 0) {
+        return;
+      }
+      setWgDevicesLoadingId(clientId);
+      try {
+        // Each delete needs its own fresh COSE signature. Update local
+        // state per success so a midway failure leaves the UI consistent
+        // with what's actually still on the server.
+        for (const device of current.devices) {
+          const auth = await buildWireGuardAuth(clientId);
+          await deletePeerMutation.mutateAsync({
+            ...auth,
+            wg_pubkey: device.pubkey,
+          });
+          removeDeviceName(device.pubkey);
+          setWgDevicesByClientId((prev) => {
+            const existing = prev[clientId];
+            if (!existing) return prev;
+            return {
+              ...prev,
+              [clientId]: {
+                ...existing,
+                devices: existing.devices.filter(
+                  (d) => d.pubkey !== device.pubkey,
+                ),
+              },
+            };
+          });
+        }
+      } catch (error) {
+        console.error("Failed to regenerate devices:", error);
+        setErrorModal(
+          error instanceof Error
+            ? error.message
+            : "Failed to remove existing devices.",
+        );
+      } finally {
+        setWgDevicesLoadingId((prev) => (prev === clientId ? null : prev));
+      }
+    },
+    [buildWireGuardAuth, deletePeerMutation, wgDevicesByClientId],
+  );
 
   const { data: clientList, isLoading: isLoadingClients } = useClientList(
     { ownerAddress: walletAddress || "" },
@@ -430,17 +615,19 @@ const Account = () => {
     setIsPurchaseLoading(true);
     try {
       await signAndSubmitTransaction(txToSubmit.txCbor);
+      const protocol = getProtocolForRegion(txToSubmit.region);
       const pendingClient = {
         id: txToSubmit.clientId,
         region: txToSubmit.region,
         duration: txToSubmit.durationMs,
         purchaseTime: new Date().toISOString(),
+        protocol,
       };
       addPendingTransaction(pendingClient);
       setPendingClientsFromStorage(
         getPendingTransactions().filter((tx) => tx.status === "pending"),
       );
-      startPolling(txToSubmit.clientId);
+      startPolling(txToSubmit.clientId, protocol);
     } catch (error) {
       console.error("Transaction error details:", error);
       setErrorModal("Failed to sign and submit transaction");
@@ -727,6 +914,20 @@ const Account = () => {
             />
           )}
 
+          {deviceModal && (
+            <DeviceConfigModal
+              isOpen
+              onClose={() => setDeviceModal(null)}
+              clientId={deviceModal.clientId}
+              regionId={deviceModal.regionId}
+              regionName={deviceModal.regionName}
+              existingDevice={deviceModal.existingDevice}
+              onDeviceCreated={(device) =>
+                handleDeviceCreated(deviceModal.clientId, device)
+              }
+            />
+          )}
+
           <div className="w-full max-w-[1200px] px-4 md:px-6 text-white flex flex-col gap-8">
 
             {/* Hero */}
@@ -981,40 +1182,89 @@ const Account = () => {
                 <div
                   className="grid grid-cols-1 gap-4 w-full mt-4"
                 >
-                  {vpnInstances.map((instance) => (
-                    <VpnInstance
-                      key={instance.id}
-                      region={instance.region}
-                      protocol={instance.protocol}
-                      status={instance.status}
-                      expires={instance.expires}
-                      shouldSpinRenew={areAllInstancesExpired}
-                      onGetConfig={() => handleGetConfig(instance.id)}
-                      onStartRenew={() =>
-                        startDurationSelection(
-                          instance.id,
-                          instance.expirationDate,
-                          "renew",
-                        )
-                      }
-                      onStartBuyTime={() =>
-                        startDurationSelection(
-                          instance.id,
-                          instance.expirationDate,
-                          "buy",
-                        )
-                      }
-                      isRenewExpanded={renewingInstanceId === instance.id}
-                      renewMode={
-                        renewingInstanceId === instance.id ? renewMode : null
-                      }
-                      renewDurationOptions={durationOptions}
-                      selectedRenewDuration={selectedRenewDuration}
-                      onSelectRenewDuration={setSelectedRenewDuration}
-                      onConfirmRenewal={handleConfirmRenewal}
-                      onCancelRenewal={handleCancelRenewal}
-                    />
-                  ))}
+                  {vpnInstances.map((instance) => {
+                    const wgState = wgDevicesByClientId[instance.id];
+                    const isWg = instance.protocol === "wireguard";
+                    return (
+                      <VpnInstance
+                        key={instance.id}
+                        region={instance.region}
+                        protocol={instance.protocol}
+                        status={instance.status}
+                        expires={instance.expires}
+                        devices={wgState?.devices ?? []}
+                        deviceLimit={wgState?.limit ?? 3}
+                        isExpanded={expandedInstanceId === instance.id}
+                        onToggleExpand={
+                          isWg ? () => handleToggleExpand(instance.id) : undefined
+                        }
+                        onRetryDevices={
+                          isWg
+                            ? () => void fetchWireGuardDevices(instance.id)
+                            : undefined
+                        }
+                        isDevicesLoading={wgDevicesLoadingId === instance.id}
+                        devicesError={wgDevicesErrorById[instance.id] ?? null}
+                        shouldSpinRenew={areAllInstancesExpired}
+                        onGetConfig={
+                          isWg ? undefined : () => handleGetConfig(instance.id)
+                        }
+                        onAddDevice={
+                          isWg
+                            ? () =>
+                                setDeviceModal({
+                                  clientId: instance.id,
+                                  regionId: instance.region,
+                                  regionName: getRegionDisplayName(
+                                    instance.region,
+                                  ),
+                                })
+                            : undefined
+                        }
+                        onRedownloadConfig={
+                          isWg
+                            ? (device) =>
+                                setDeviceModal({
+                                  clientId: instance.id,
+                                  regionId: instance.region,
+                                  regionName: getRegionDisplayName(
+                                    instance.region,
+                                  ),
+                                  existingDevice: device,
+                                })
+                            : undefined
+                        }
+                        onRegenerateAll={
+                          isWg
+                            ? () => void handleRegenerateAll(instance.id)
+                            : undefined
+                        }
+                        onStartRenew={() =>
+                          startDurationSelection(
+                            instance.id,
+                            instance.expirationDate,
+                            "renew",
+                          )
+                        }
+                        onStartBuyTime={() =>
+                          startDurationSelection(
+                            instance.id,
+                            instance.expirationDate,
+                            "buy",
+                          )
+                        }
+                        isRenewExpanded={renewingInstanceId === instance.id}
+                        renewMode={
+                          renewingInstanceId === instance.id ? renewMode : null
+                        }
+                        renewDurationOptions={durationOptions}
+                        selectedRenewDuration={selectedRenewDuration}
+                        onSelectRenewDuration={setSelectedRenewDuration}
+                        onConfirmRenewal={handleConfirmRenewal}
+                        onCancelRenewal={handleCancelRenewal}
+                      />
+                    );
+                  })}
                 </div>
               ) : (
                 <div className="mt-4 text-center text-white/80">

--- a/src/utils/pendingTransactions.ts
+++ b/src/utils/pendingTransactions.ts
@@ -1,3 +1,6 @@
+import type { VpnProtocol } from "../api/types";
+import { getProtocolForRegion } from "../components/RegionSelect";
+
 export interface PendingTransaction {
   id: string;
   region: string;
@@ -6,6 +9,7 @@ export interface PendingTransaction {
   status: "pending" | "complete";
   attempts: number;
   maxAttempts: number;
+  protocol: VpnProtocol;
 }
 
 const STORAGE_KEY = "vpn_pending_transactions";
@@ -17,7 +21,14 @@ export function getPendingTransactions(): PendingTransaction[] {
     if (!stored) return [];
 
     const transactions: PendingTransaction[] = JSON.parse(stored);
-    return transactions;
+    // Backfill protocol for records written before the field existed.
+    // Re-derive from the stored region so legacy WireGuard purchases keep
+    // routing through /client/list polling instead of being misclassified
+    // as OpenVPN.
+    return transactions.map((tx) => ({
+      ...tx,
+      protocol: tx.protocol ?? getProtocolForRegion(tx.region),
+    }));
   } catch (error) {
     console.error("Failed to get pending transactions:", error);
     return [];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WireGuard device management: create, download, regenerate devices with per-request auth and improved device lifecycle handling
  * Region display helper exported for reuse

* **Changes**
  * Improved device UX: loading indicators, retry on error, optimistic list updates, and externalized expand/collapse control
  * "Get Config" now hidden for WireGuard instances
  * Pending transactions now include protocol and polling respects protocol changes

* **Tests**
  * Updated tests to cover new WireGuard register/delete flows and device-name handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->