### PR TITLE
feat: use session token for API auth

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -11,6 +11,18 @@ import type {
 
 export const API_BASE_URL = import.meta.env.DEV ? "/api" : "/api";
 
+/** Error thrown by the API client, carrying the HTTP status code. */
+export class HttpError extends Error {
+  status: number;
+  constructor(status: number, statusText: string, body: string) {
+    super(
+      `API Error: ${status} ${statusText}${body ? ` - ${body}` : ""}`,
+    );
+    this.name = "HttpError";
+    this.status = status;
+  }
+}
+
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -40,9 +52,7 @@ export async function apiClient<T>(
 
     if (!response.ok) {
       const errorText = await response.text();
-      throw new Error(
-        `API Error: ${response.status} ${response.statusText}${errorText ? ` - ${errorText}` : ""}`,
-      );
+      throw new HttpError(response.status, response.statusText, errorText);
     }
 
     // Handle empty responses explicitly
@@ -108,9 +118,7 @@ export async function postPlainText(
 
     if (!response.ok) {
       const errorText = await response.text();
-      throw new Error(
-        `API Error: ${response.status} ${response.statusText}${errorText ? ` - ${errorText}` : ""}`,
-      );
+      throw new HttpError(response.status, response.statusText, errorText);
     }
 
     return response.text();
@@ -248,15 +256,18 @@ export async function checkClientAvailableWithGraceful404(
 
 export function getClientProfile(
   request: ClientProfileRequest,
+  headers?: Record<string, string>,
 ): Promise<string> {
   const url = `${API_BASE_URL}/client/profile`;
+  const requestHeaders = {
+    "Content-Type": "application/json",
+    accept: "application/json",
+    ...headers,
+  };
 
   return fetch(url, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      accept: "application/json",
-    },
+    headers: requestHeaders,
     body: JSON.stringify(request),
     redirect: "manual",
   }).then(async (response) => {
@@ -275,10 +286,7 @@ export function getClientProfile(
       console.log("Got opaque redirect, using follow approach...");
       return fetch(url, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          accept: "application/json",
-        },
+        headers: requestHeaders,
         body: JSON.stringify(request),
         redirect: "follow",
       }).then((finalResponse) => {
@@ -292,9 +300,7 @@ export function getClientProfile(
 
     if (!response.ok) {
       const errorText = await response.text();
-      throw new Error(
-        `API Error: ${response.status} ${response.statusText}${errorText ? ` - ${errorText}` : ""}`,
-      );
+      throw new HttpError(response.status, response.statusText, errorText);
     }
 
     return response.text();

--- a/src/api/hooks/__tests__/useWireGuard.test.tsx
+++ b/src/api/hooks/__tests__/useWireGuard.test.tsx
@@ -8,7 +8,7 @@ import {
   useWireGuardDevices,
 } from "../useWireGuard";
 import { createTestQueryClient } from "../../../test/utils";
-import * as client from "../../client";
+import * as session from "../../session";
 import type {
   WireGuardRegisterRequest,
   WireGuardRegisterResponse,
@@ -19,15 +19,18 @@ import type {
   WireGuardDevicesResponse,
 } from "../../types";
 
-vi.mock("../../client", () => ({
-  post: vi.fn(),
-  postPlainText: vi.fn(),
-  del: vi.fn(),
+// The hooks authenticate via the session layer, which attaches a Bearer
+// token (minting one with a single wallet signature on first use). Tests mock
+// that layer so they exercise the hooks without a real wallet.
+vi.mock("../../session", () => ({
+  authedPost: vi.fn(),
+  authedPostPlainText: vi.fn(),
+  authedDel: vi.fn(),
 }));
 
-const mockedPost = vi.mocked(client.post);
-const mockedPostPlainText = vi.mocked(client.postPlainText);
-const mockedDel = vi.mocked(client.del);
+const mockedPost = vi.mocked(session.authedPost);
+const mockedPostPlainText = vi.mocked(session.authedPostPlainText);
+const mockedDel = vi.mocked(session.authedDel);
 
 describe("useWireGuard hooks", () => {
   let queryClient: QueryClient;
@@ -44,9 +47,6 @@ describe("useWireGuard hooks", () => {
   describe("useWireGuardRegister", () => {
     const mockRequest: WireGuardRegisterRequest = {
       client_id: "test-client-123",
-      timestamp: Date.now(),
-      signature: "hex-signature",
-      key: "hex-key",
       wg_pubkey: "base64-public-key",
     };
 
@@ -130,9 +130,6 @@ describe("useWireGuard hooks", () => {
   describe("useWireGuardProfile", () => {
     const mockRequest: WireGuardProfileRequest = {
       client_id: "test-client-123",
-      timestamp: Date.now(),
-      signature: "hex-signature",
-      key: "hex-key",
       wg_pubkey: "base64-public-key",
     };
 
@@ -216,9 +213,6 @@ Endpoint = vpn.example.com:51820`;
   describe("useWireGuardDeletePeer", () => {
     const mockRequest: WireGuardPeerRequest = {
       client_id: "test-client-123",
-      timestamp: Date.now(),
-      signature: "hex-signature",
-      key: "hex-key",
       wg_pubkey: "base64-public-key-to-delete",
     };
 
@@ -294,9 +288,6 @@ Endpoint = vpn.example.com:51820`;
   describe("useWireGuardDevices", () => {
     const mockRequest: WireGuardDevicesRequest = {
       client_id: "test-client-123",
-      timestamp: Date.now(),
-      signature: "hex-signature",
-      key: "hex-key",
     };
 
     const mockResponse: WireGuardDevicesResponse = {
@@ -435,9 +426,6 @@ Endpoint = vpn.example.com:51820`;
 
       result.current.mutate({
         client_id: "test",
-        timestamp: Date.now(),
-        signature: "sig",
-        key: "key",
         wg_pubkey: "pubkey",
       });
 
@@ -473,9 +461,6 @@ Endpoint = vpn.example.com:51820`;
 
       const mockRequest: WireGuardRegisterRequest = {
         client_id: "test",
-        timestamp: Date.now(),
-        signature: "sig",
-        key: "key",
         wg_pubkey: "pubkey",
       };
 

--- a/src/api/hooks/useClientProfile.ts
+++ b/src/api/hooks/useClientProfile.ts
@@ -1,30 +1,10 @@
 import { useMutation } from "@tanstack/react-query";
-import { getClientProfile } from "../client";
-import { useWalletStore } from "../../stores/walletStore";
-
-interface SignDataResponse {
-  key: string;
-  signature: string;
-}
+import { authedGetClientProfile } from "../session";
 
 export function useClientProfile() {
-  const { signMessage } = useWalletStore();
-
   return useMutation({
-    mutationFn: async (clientId: string) => {
-      const timestamp = Math.floor(Date.now() / 1000).toString();
-      const challenge = `${clientId}${timestamp}`;
-
-      const signResult = (await signMessage(challenge)) as SignDataResponse;
-
-      const profileRequest = {
-        id: clientId,
-        key: signResult.key,
-        signature: signResult.signature,
-      };
-
-      return await getClientProfile(profileRequest);
-    },
+    // Authenticates with a session token (signs once, then reuses it).
+    mutationFn: (clientId: string) => authedGetClientProfile(clientId),
     mutationKey: ["clientProfile"],
   });
 }

--- a/src/api/hooks/useWireGuard.ts
+++ b/src/api/hooks/useWireGuard.ts
@@ -4,7 +4,7 @@ import {
   type UseMutationOptions,
   type UseQueryOptions,
 } from "@tanstack/react-query";
-import { post, postPlainText, del } from "../client";
+import { authedPost, authedPostPlainText, authedDel } from "../session";
 import type {
   WireGuardRegisterRequest,
   WireGuardRegisterResponse,
@@ -25,7 +25,7 @@ export function useWireGuardRegister(
 ) {
   return useMutation({
     mutationFn: (data: WireGuardRegisterRequest) =>
-      post<WireGuardRegisterResponse>("/client/wg-register", data),
+      authedPost<WireGuardRegisterResponse>("/client/wg-register", data),
     ...options,
   });
 }
@@ -36,7 +36,7 @@ export function useWireGuardProfile(
 ) {
   return useMutation({
     mutationFn: (data: WireGuardProfileRequest) =>
-      postPlainText("/client/wg-profile", data), // Returns text/plain
+      authedPostPlainText("/client/wg-profile", data), // Returns text/plain
     ...options,
   });
 }
@@ -51,7 +51,7 @@ export function useWireGuardDeletePeer(
 ) {
   return useMutation({
     mutationFn: (data: WireGuardPeerRequest) =>
-      del<WireGuardDeleteResponse>("/client/wg-peer", data),
+      authedDel<WireGuardDeleteResponse>("/client/wg-peer", data),
     ...options,
   });
 }
@@ -66,7 +66,8 @@ export function useWireGuardDevices(
 ) {
   return useQuery({
     queryKey: ["wireGuardDevices", request.client_id],
-    queryFn: () => post<WireGuardDevicesResponse>("/client/wg-devices", request),
+    queryFn: () =>
+      authedPost<WireGuardDevicesResponse>("/client/wg-devices", request),
     ...options,
   });
 }

--- a/src/api/session.ts
+++ b/src/api/session.ts
@@ -1,0 +1,63 @@
+import {
+  HttpError,
+  post,
+  postPlainText,
+  del,
+  getClientProfile,
+} from "./client";
+import { useWalletStore } from "../stores/walletStore";
+
+/**
+ * Runs an authenticated API call, attaching a wallet-wide Bearer session
+ * token. If the call fails with 401 (expired/invalid token), the cached token
+ * is cleared and the call is retried once with a fresh token.
+ */
+async function withSessionToken<T>(
+  call: (headers: Record<string, string>) => Promise<T>,
+): Promise<T> {
+  const store = useWalletStore.getState();
+  const token = await store.getSessionToken();
+  try {
+    return await call({ Authorization: `Bearer ${token}` });
+  } catch (error) {
+    if (error instanceof HttpError && error.status === 401) {
+      // Conditional clear: only evicts if `token` is still cached, so a
+      // concurrent 401 cannot delete a token another call already refreshed.
+      await store.clearSessionToken(token);
+      const fresh = await store.getSessionToken();
+      return await call({ Authorization: `Bearer ${fresh}` });
+    }
+    throw error;
+  }
+}
+
+/** Authenticated POST returning JSON. */
+export function authedPost<T>(endpoint: string, data?: unknown): Promise<T> {
+  return withSessionToken((headers) => post<T>(endpoint, data, { headers }));
+}
+
+/** Authenticated POST returning text/plain. */
+export function authedPostPlainText(
+  endpoint: string,
+  data?: unknown,
+): Promise<string> {
+  return withSessionToken((headers) =>
+    postPlainText(endpoint, data, { headers }),
+  );
+}
+
+/** Authenticated DELETE returning JSON. */
+export function authedDel<T>(endpoint: string, data?: unknown): Promise<T> {
+  return withSessionToken((headers) => del<T>(endpoint, data, { headers }));
+}
+
+/**
+ * Authenticated OpenVPN profile fetch. Returns the pre-signed config URL (or
+ * config text). Uses the wallet-wide session token instead of a per-request
+ * signature; clientId names which subscription's profile to fetch.
+ */
+export function authedGetClientProfile(clientId: string): Promise<string> {
+  return withSessionToken((headers) =>
+    getClientProfile({ id: clientId }, headers),
+  );
+}

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -63,9 +63,8 @@ export interface ClientAvailableResponse {
 }
 
 export interface ClientProfileRequest {
+  /** Hex-encoded NFT asset name; auth is via the Bearer session token. */
   id: string;
-  key: string;
-  signature: string;
 }
 
 export interface TxRenewRequest {
@@ -82,22 +81,34 @@ export interface TxRenewResponse {
 }
 
 // ============================================================================
+// Session Auth Types
+// ============================================================================
+
+/**
+ * POST /api/auth/session - Exchange a wallet-signed challenge for a session
+ * token covering all subscriptions owned by the wallet.
+ */
+export interface SessionTokenResponse {
+  /** Signed JWT session token to send as `Authorization: Bearer <token>` */
+  token: string;
+  /** Unix timestamp (seconds) at which the token expires */
+  expires_at: number;
+}
+
+// ============================================================================
 // WireGuard Types
 // ============================================================================
 
 /**
- * Authentication payload required for all WireGuard API requests.
- * Uses COSE signature verification with Ed25519 keys.
+ * Authentication payload for WireGuard API requests.
+ *
+ * Requests are authenticated with an `Authorization: Bearer <token>` header
+ * (see {@link SessionTokenResponse}); `client_id` only names the target
+ * subscription in the body.
  */
 export interface WireGuardAuthPayload {
   /** Hex-encoded NFT asset name (subscription identifier) */
   client_id: string;
-  /** Unix timestamp (must be within 15 minutes of server time) */
-  timestamp: number;
-  /** Hex-encoded COSE Sign1 message (payload = client_id + timestamp) */
-  signature: string;
-  /** Hex-encoded COSE Key (Ed25519 public key) */
-  key: string;
 }
 
 /**

--- a/src/components/DeviceConfigModal.tsx
+++ b/src/components/DeviceConfigModal.tsx
@@ -8,13 +8,7 @@ import {
   useWireGuardProfile,
   useWireGuardRegister,
 } from '../api/hooks/useWireGuard';
-import { useWalletStore } from '../stores/walletStore';
 import type { WireGuardDevice } from '../api/types';
-
-interface SignDataResponse {
-  key: string;
-  signature: string;
-}
 
 interface DeviceConfigModalProps {
   isOpen: boolean;
@@ -70,14 +64,8 @@ export function DeviceConfigModal({
   const inputRef = useRef<HTMLInputElement>(null);
   const copiedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const copyErrorTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // Last unix timestamp (in seconds) we minted for a WireGuard auth payload.
-  // Bumped monotonically so back-to-back signs in the same wall second don't
-  // produce identical (client_id, timestamp, signature) triples — Ed25519
-  // signatures are deterministic and the backend rejects replays.
-  const lastAuthTimestampRef = useRef(0);
 
   // Hooks
-  const { signMessage } = useWalletStore();
   const wireGuardRegister = useWireGuardRegister();
   const wireGuardProfile = useWireGuardProfile();
   const wireGuardDeletePeer = useWireGuardDeletePeer();
@@ -219,23 +207,9 @@ export function DeviceConfigModal({
       // because we never persist the private key.
       const newKeypair = await generateWireGuardKeypair();
 
-      // Each WireGuard endpoint takes a fresh COSE auth payload — the
-      // backend treats every (client_id, timestamp, signature) triple as
-      // one-shot, so we sign per call. Timestamp is bumped monotonically
-      // to avoid collisions when several calls land in the same second.
-      const buildAuth = async () => {
-        const now = Math.floor(Date.now() / 1000);
-        const timestamp = Math.max(now, lastAuthTimestampRef.current + 1);
-        lastAuthTimestampRef.current = timestamp;
-        const challenge = `${clientId}${timestamp}`;
-        const signResult = (await signMessage(challenge)) as SignDataResponse;
-        return {
-          client_id: clientId,
-          timestamp,
-          signature: signResult.signature,
-          key: signResult.key,
-        };
-      };
+      // The WireGuard endpoints authenticate with a session token that is
+      // minted on the first call and reused for the rest, so the wallet only
+      // prompts the user to sign once for the whole flow.
 
       // Step 2: Register the new pubkey. /wg-profile returns 404 if the
       // pubkey isn't registered, so this must come first.
@@ -243,16 +217,14 @@ export function DeviceConfigModal({
       // a downstream failure can't leave the user with no device. The
       // trade-off is that an at-limit re-download will fail with "device
       // limit reached" and the user will need to use Regenerate All.
-      const registerAuth = await buildAuth();
       await wireGuardRegister.mutateAsync({
-        ...registerAuth,
+        client_id: clientId,
         wg_pubkey: newKeypair.publicKey,
       });
 
       // Step 3: Fetch the config text for the newly-registered pubkey.
-      const profileAuth = await buildAuth();
       const configText = await wireGuardProfile.mutateAsync({
-        ...profileAuth,
+        client_id: clientId,
         wg_pubkey: newKeypair.publicKey,
       });
 
@@ -261,9 +233,8 @@ export function DeviceConfigModal({
       // new device plus an orphan they can clean up via Regenerate All.
       if (existingDevice) {
         try {
-          const deleteAuth = await buildAuth();
           await wireGuardDeletePeer.mutateAsync({
-            ...deleteAuth,
+            client_id: clientId,
             wg_pubkey: existingDevice.pubkey,
           });
           removeDeviceName(existingDevice.pubkey);
@@ -308,7 +279,7 @@ export function DeviceConfigModal({
     } finally {
       setIsGenerating(false);
     }
-  }, [deviceName, existingDevice, clientId, signMessage, wireGuardRegister, wireGuardProfile, wireGuardDeletePeer, onDeviceCreated]);
+  }, [deviceName, existingDevice, clientId, wireGuardRegister, wireGuardProfile, wireGuardDeletePeer, onDeviceCreated]);
 
   const handleNameSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback, useRef } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import { useWalletStore } from "../stores/walletStore";
 import {
   useRefData,
@@ -32,7 +32,7 @@ import RegionSelect, {
   getProtocolForRegion,
   getRegionDisplayName,
 } from "../components/RegionSelect";
-import { post } from "../api/client";
+import { authedPost } from "../api/session";
 import { getDeviceName, removeDeviceName } from "../utils/deviceNames";
 import {
   getPendingTransactions,
@@ -53,7 +53,6 @@ const Account = () => {
     walletAddress,
     signAndSubmitTransaction,
     setVpnConfigUrl,
-    signMessage,
   } = useWalletStore();
   const [isPurchaseLoading, setIsPurchaseLoading] = useState<boolean>(false);
   const [isConfigLoading, setIsConfigLoading] = useState<boolean>(false);
@@ -161,34 +160,6 @@ const Account = () => {
 
   const deletePeerMutation = useWireGuardDeletePeer();
 
-  // Build the COSE auth payload required by every WireGuard endpoint.
-  // The backend treats each (client_id, timestamp, signature) as one-shot,
-  // so we sign fresh for every call rather than caching. Timestamp is
-  // bumped monotonically per component instance so back-to-back signs in
-  // the same wall second don't produce identical triples (Ed25519 is
-  // deterministic, identical input → identical signature → server replay
-  // rejection).
-  const lastAuthTimestampRef = useRef(0);
-  const buildWireGuardAuth = useCallback(
-    async (clientId: string) => {
-      const now = Math.floor(Date.now() / 1000);
-      const timestamp = Math.max(now, lastAuthTimestampRef.current + 1);
-      lastAuthTimestampRef.current = timestamp;
-      const challenge = `${clientId}${timestamp}`;
-      const signResult = (await signMessage(challenge)) as {
-        key: string;
-        signature: string;
-      };
-      return {
-        client_id: clientId,
-        timestamp,
-        signature: signResult.signature,
-        key: signResult.key,
-      };
-    },
-    [signMessage],
-  );
-
   const enrichDevices = useCallback(
     (raw: WireGuardDevicesResponse["devices"]): WireGuardDevice[] =>
       raw.map((d) => ({
@@ -205,10 +176,11 @@ const Account = () => {
       setWgDevicesLoadingId(clientId);
       setWgDevicesErrorById((prev) => ({ ...prev, [clientId]: null }));
       try {
-        const auth = await buildWireGuardAuth(clientId);
-        const response = await post<WireGuardDevicesResponse>(
+        // Authenticates with a wallet-wide session token (signs once, then
+        // reuses it across all subscriptions).
+        const response = await authedPost<WireGuardDevicesResponse>(
           "/client/wg-devices",
-          auth,
+          { client_id: clientId },
         );
         setWgDevicesByClientId((prev) => ({
           ...prev,
@@ -230,7 +202,7 @@ const Account = () => {
         setWgDevicesLoadingId((prev) => (prev === clientId ? null : prev));
       }
     },
-    [buildWireGuardAuth, enrichDevices],
+    [enrichDevices],
   );
 
   const handleToggleExpand = useCallback(
@@ -275,13 +247,12 @@ const Account = () => {
       }
       setWgDevicesLoadingId(clientId);
       try {
-        // Each delete needs its own fresh COSE signature. Update local
-        // state per success so a midway failure leaves the UI consistent
-        // with what's actually still on the server.
+        // Deletes reuse the cached session token (one signature for the
+        // whole batch). Update local state per success so a midway failure
+        // leaves the UI consistent with what's actually still on the server.
         for (const device of current.devices) {
-          const auth = await buildWireGuardAuth(clientId);
           await deletePeerMutation.mutateAsync({
-            ...auth,
+            client_id: clientId,
             wg_pubkey: device.pubkey,
           });
           removeDeviceName(device.pubkey);
@@ -310,7 +281,7 @@ const Account = () => {
         setWgDevicesLoadingId((prev) => (prev === clientId ? null : prev));
       }
     },
-    [buildWireGuardAuth, deletePeerMutation, wgDevicesByClientId],
+    [deletePeerMutation, wgDevicesByClientId],
   );
 
   const { data: clientList, isLoading: isLoadingClients } = useClientList(

--- a/src/stores/walletStore.ts
+++ b/src/stores/walletStore.ts
@@ -2,7 +2,8 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import type { CardanoWalletApi } from "../types/cardano";
 import { Address, Value, Tx } from "@harmoniclabs/cardano-ledger-ts";
-import { submitTransaction as submitTransactionApi } from "../api/client";
+import { submitTransaction as submitTransactionApi, post } from "../api/client";
+import type { SessionTokenResponse } from "../api/types";
 
 const APP_NETWORK = (
   import.meta.env.VITE_CARDANO_NETWORK ?? "preprod"
@@ -39,7 +40,19 @@ interface WalletState {
   openWalletModal: () => void;
   connect: (walletName: string) => Promise<void>;
   disconnect: () => void;
-  signMessage: (message: string) => Promise<unknown>;
+  signMessage: (message: string) => Promise<{ key: string; signature: string }>;
+  /**
+   * Returns a valid wallet-wide session token, signing a challenge with the
+   * wallet only when no unexpired cached token exists. One token covers every
+   * subscription owned by the connected wallet.
+   */
+  getSessionToken: () => Promise<string>;
+  /**
+   * Drops the cached session token for the wallet after a 401 — but only if the
+   * cached token still matches `failedToken`, so a concurrent refresh that
+   * already minted a new token is not clobbered.
+   */
+  clearSessionToken: (failedToken: string) => Promise<void>;
   signTransaction: (txCbor: string) => Promise<string>; // Returns signed transaction CBOR
   submitTransaction: (signedTxCbor: string) => Promise<string>;
   toggleWalletModal: () => void;
@@ -68,6 +81,28 @@ const decodeHexAddress = (hexAddress: string): string | null => {
     return null;
   }
 };
+
+// In-memory session token cache, keyed by wallet address. Kept out of the
+// persisted store (and localStorage) to limit token theft via XSS; tokens are
+// short-lived and cheap to re-mint with a single signature. One token per
+// wallet covers all of that wallet's subscriptions.
+const sessionTokenCache = new Map<
+  string,
+  { token: string; expiresAt: number }
+>();
+
+// In-flight token mints, keyed by cacheKey. Concurrent callers with an empty or
+// expired cache share the first caller's signature + exchange instead of each
+// prompting the wallet and minting a duplicate token.
+const pendingSessionTokens = new Map<string, Promise<string>>();
+
+// Re-mint a token slightly before it actually expires to avoid races with
+// in-flight requests near the boundary.
+const SESSION_TOKEN_REFRESH_SKEW_SECONDS = 60;
+
+// Domain-separated session challenge prefix; must match the backend's
+// sessionChallengePrefix so the signature is accepted at /auth/session.
+const SESSION_CHALLENGE_PREFIX = "vpn-session:";
 
 export const useWalletStore = create<WalletState>()(
   persist(
@@ -213,6 +248,8 @@ export const useWalletStore = create<WalletState>()(
       },
 
       disconnect: () => {
+        sessionTokenCache.clear();
+        pendingSessionTokens.clear();
         set({
           isConnected: false,
           isEnabled: false,
@@ -243,6 +280,81 @@ export const useWalletStore = create<WalletState>()(
         } catch (error) {
           console.error("Failed to sign message:", error);
           throw error;
+        }
+      },
+
+      getSessionToken: async () => {
+        const { walletApi, signMessage } = get();
+        // Key the cache by the live signing address from the currently enabled
+        // wallet, rather than the (possibly stale or not-yet-loaded) persisted
+        // walletAddress. Fail closed if no wallet is connected so a token is
+        // never cached/reused under an empty key or a key belonging to a
+        // different wallet.
+        if (!walletApi) {
+          throw new Error("No wallet connected");
+        }
+        const cacheKey = await walletApi.getChangeAddress();
+        const now = Math.floor(Date.now() / 1000);
+        const cached = sessionTokenCache.get(cacheKey);
+        if (
+          cached &&
+          cached.expiresAt - SESSION_TOKEN_REFRESH_SKEW_SECONDS > now
+        ) {
+          return cached.token;
+        }
+
+        // Coalesce concurrent mints for the same wallet: the first caller signs
+        // and exchanges, later callers await the same promise so the wallet is
+        // only prompted once.
+        const inFlight = pendingSessionTokens.get(cacheKey);
+        if (inFlight) {
+          return inFlight;
+        }
+
+        const mint = (async () => {
+          // Sign a fresh challenge once for the whole wallet and exchange it
+          // for a token covering all of its subscriptions.
+          const challenge = `${SESSION_CHALLENGE_PREFIX}${now}`;
+          const { signature, key } = await signMessage(challenge);
+
+          const resp = await post<SessionTokenResponse>("/auth/session", {
+            signature,
+            key,
+          });
+
+          // Only cache if the same wallet is still connected. If a disconnect
+          // (or wallet switch) happened while minting, caching here would
+          // resurrect a token after disconnect cleared the cache. The check and
+          // set are synchronous, so disconnect cannot interleave between them.
+          if (get().walletApi === walletApi) {
+            sessionTokenCache.set(cacheKey, {
+              token: resp.token,
+              expiresAt: resp.expires_at,
+            });
+          }
+          return resp.token;
+        })();
+
+        pendingSessionTokens.set(cacheKey, mint);
+        try {
+          return await mint;
+        } finally {
+          pendingSessionTokens.delete(cacheKey);
+        }
+      },
+
+      clearSessionToken: async (failedToken: string) => {
+        const { walletApi } = get();
+        if (!walletApi) {
+          return;
+        }
+        // Use the same live key derivation as getSessionToken so the right
+        // entry is targeted.
+        const cacheKey = await walletApi.getChangeAddress();
+        // Only evict if the cached token is still the one that failed, so a
+        // concurrent 401 cannot delete a token another call already refreshed.
+        if (sessionTokenCache.get(cacheKey)?.token === failedToken) {
+          sessionTokenCache.delete(cacheKey);
         }
       },
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch API auth from per-request wallet signatures to a short‑lived, wallet‑wide session token via `POST /auth/session`. This removes repeated signing prompts, standardizes auth across endpoints, and retries once on 401.

- **New Features**
  - Added session layer (`authedPost`, `authedPostPlainText`, `authedDel`, `authedGetClientProfile`) that attaches `Authorization: Bearer <token>` and re‑mints on 401.
  - In-memory per-wallet token cache in `walletStore` with `getSessionToken`/`clearSessionToken`, early refresh skew, coalesced concurrent mints, conditional eviction on 401, and clear-on-disconnect.
  - Introduced `HttpError` in the API client to expose HTTP status codes and response text.

- **Refactors**
  - Moved WireGuard and client profile flows to the session layer in hooks and UI (`useWireGuard*`, `useClientProfile`, `Account`, `DeviceConfigModal`); removed per-request signing and `signMessage` usage.
  - `getClientProfile` now accepts headers; `useClientProfile` calls `authedGetClientProfile`.
  - Types: removed `key`/`signature` from `ClientProfileRequest` and `WireGuardAuthPayload`; added `SessionTokenResponse`.

<sup>Written for commit 93acb7f1d905b031ecebb1fc80d4ea90ab9ae662. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/vpn-frontend/pull/286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added wallet-wide, session-token authentication for secured client profile and WireGuard operations, reducing repeated authorization prompts.
  * Introduced authenticated API helpers to reuse tokens across requests.
* **Bug Fixes**
  * Improved HTTP error reporting with clearer status details and response body text.
  * Automatically retries authenticated requests once when the session token expires.
* **Changes / UI Impact**
  * Updated device/profile configuration flows to send only `client_id` (and required public keys) using session auth.
* **Tests**
  * Updated hook tests to mock the authenticated session layer and adjusted request payload expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->