### PR TITLE
fix: show pending spinner for wireguard renewals

### DIFF
--- a/src/api/hooks/useClientPolling.ts
+++ b/src/api/hooks/useClientPolling.ts
@@ -18,6 +18,10 @@ interface PollingState {
   attempts: number;
   maxAttempts: number;
   protocol: VpnProtocol;
+  // Set for renewals: the pre-renewal expiration (ms). When present, the tx is
+  // "ready" once the client's indexed expiration exceeds it, rather than merely
+  // existing (which is always true for a renewed, pre-existing client).
+  expectedExpirationAfter: number | null;
 }
 
 const DEFAULT_MAX_ATTEMPTS = 20;
@@ -34,6 +38,7 @@ export function useClientPolling() {
         attempts: firstPending.attempts,
         maxAttempts: DEFAULT_MAX_ATTEMPTS,
         protocol: firstPending.protocol,
+        expectedExpirationAfter: firstPending.expectedExpirationAfter ?? null,
       };
     }
 
@@ -43,6 +48,7 @@ export function useClientPolling() {
       attempts: 0,
       maxAttempts: DEFAULT_MAX_ATTEMPTS,
       protocol: "openvpn",
+      expectedExpirationAfter: null,
     };
   });
 
@@ -54,6 +60,7 @@ export function useClientPolling() {
       clientId: string,
       protocol: VpnProtocol,
       initialAttempts: number = 0,
+      expectedExpirationAfter: number | null = null,
     ) => {
       setPollingState({
         isPolling: true,
@@ -61,6 +68,7 @@ export function useClientPolling() {
         attempts: initialAttempts,
         maxAttempts: DEFAULT_MAX_ATTEMPTS,
         protocol,
+        expectedExpirationAfter,
       });
     },
     [],
@@ -97,12 +105,28 @@ export function useClientPolling() {
       try {
         let isReady = false;
 
-        if (pollingState.protocol === "wireguard") {
-          // WireGuard subscriptions don't expose /client/available — they're
-          // ready as soon as the on-chain transaction confirms and the new
-          // clientId surfaces in /client/list. If the wallet isn't connected
-          // we treat this attempt as "not ready" and keep counting toward
-          // maxAttempts so the poll eventually gives up instead of stalling.
+        if (pollingState.expectedExpirationAfter !== null) {
+          // Renewal: the client already exists, so "exists" tells us nothing.
+          // Wait until the indexed expiration advances past its pre-renewal
+          // value. /client/list carries expiration for both protocols. If the
+          // wallet isn't connected we treat this as "not ready" and keep
+          // counting toward maxAttempts so the poll eventually gives up.
+          const ownerAddress = useWalletStore.getState().walletAddress;
+          const list = ownerAddress
+            ? await getClientListWithGraceful404({ ownerAddress })
+            : [];
+          const client = list.find((c) => c.id === pollingState.clientId);
+          isReady =
+            !!client &&
+            new Date(client.expiration).getTime() >
+              pollingState.expectedExpirationAfter;
+        } else if (pollingState.protocol === "wireguard") {
+          // New signup (WireGuard): subscriptions don't expose
+          // /client/available — they're ready as soon as the on-chain
+          // transaction confirms and the new clientId surfaces in
+          // /client/list. If the wallet isn't connected we treat this attempt
+          // as "not ready" and keep counting toward maxAttempts so the poll
+          // eventually gives up instead of stalling.
           const ownerAddress = useWalletStore.getState().walletAddress;
           const list = ownerAddress
             ? await getClientListWithGraceful404({ ownerAddress })
@@ -189,6 +213,7 @@ export function useClientPolling() {
     pollingState.attempts,
     pollingState.maxAttempts,
     pollingState.protocol,
+    pollingState.expectedExpirationAfter,
     queryClient,
     stopPolling,
   ]);

--- a/src/components/VpnInstance.tsx
+++ b/src/components/VpnInstance.tsx
@@ -33,6 +33,9 @@ interface VpnInstanceProps {
   onConfirmRenewal?: () => void;
   onCancelRenewal?: () => void;
   shouldSpinRenew?: boolean;
+  // True while a submitted renewal/buy-time tx is being indexed, so the card
+  // shows a spinner and the new expiration appears without a manual refresh.
+  isRenewing?: boolean;
 }
 
 /**
@@ -85,6 +88,7 @@ const VpnInstance = ({
   onConfirmRenewal,
   onCancelRenewal,
   shouldSpinRenew = false,
+  isRenewing = false,
 }: VpnInstanceProps) => {
   const isWireGuard = protocol === "wireguard";
 
@@ -151,6 +155,12 @@ const VpnInstance = ({
               }`}
             ></span>
           </div>
+          {isRenewing && (
+            <div className="flex items-center gap-2 text-xs text-white/80">
+              <div className="w-3 h-3 border-2 border-white/60 border-t-transparent rounded-full animate-spin" />
+              Renewing…
+            </div>
+          )}
         </div>
       </div>
 

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -65,6 +65,9 @@ const Account = () => {
     region: string;
     priceAda: string;
     newExpiration?: string;
+    // For renew/buy-time: the subscription's expiration (ms) before renewal,
+    // so polling can wait for the indexed expiration to advance past it.
+    previousExpiration?: number;
   } | null>(null);
   const [errorModal, setErrorModal] = useState<string | null>(null);
   const [profileDeliveryModal, setProfileDeliveryModal] = useState<{
@@ -152,7 +155,11 @@ const Account = () => {
 
   // Initialize hooks first
   const clientProfileMutation = useClientProfile();
-  const { startPolling } = useClientPolling();
+  const {
+    startPolling,
+    isPolling,
+    clientId: pollingClientId,
+  } = useClientPolling();
 
   const signupMutation = useSignup();
 
@@ -446,27 +453,37 @@ const Account = () => {
   useEffect(() => {
     if (!dedupedClientList || pendingClientsFromStorage.length === 0) return;
 
-    const availableClientIds = new Set(
-      dedupedClientList.map((client) => client.id),
+    const clientById = new Map(
+      dedupedClientList.map((client) => [client.id, client]),
     );
 
-    const hasCompleted = pendingClientsFromStorage.some((pending) =>
-      availableClientIds.has(pending.id),
-    );
-    if (!hasCompleted) return;
+    // A signup completes once its client appears. A renewal reuses an existing
+    // client, so it completes only once the indexed expiration advances past
+    // its pre-renewal value — until then the record must persist so
+    // useClientPolling()/getActivePendingTransactions() can restore the
+    // "Renewing…" state after a reload.
+    const isComplete = (pending: (typeof pendingClientsFromStorage)[number]) => {
+      const client = clientById.get(pending.id);
+      if (!client) return false;
+      if (pending.expectedExpirationAfter == null) return true;
+      return (
+        new Date(client.expiration).getTime() > pending.expectedExpirationAfter
+      );
+    };
 
-    pendingClientsFromStorage.forEach((pending) => {
-      if (availableClientIds.has(pending.id)) {
-        console.log(
-          `Removing completed transaction ${pending.id} from localStorage`,
-        );
-        removePendingTransaction(pending.id);
-      }
+    const completedIds = new Set(
+      pendingClientsFromStorage.filter(isComplete).map((p) => p.id),
+    );
+    if (completedIds.size === 0) return;
+
+    completedIds.forEach((id) => {
+      console.log(`Removing completed transaction ${id} from localStorage`);
+      removePendingTransaction(id);
     });
 
     const timeoutId = window.setTimeout(() => {
       setPendingClientsFromStorage((prev) =>
-        prev.filter((pending) => !availableClientIds.has(pending.id)),
+        prev.filter((pending) => !completedIds.has(pending.id)),
       );
     }, 0);
 
@@ -593,12 +610,18 @@ const Account = () => {
         duration: txToSubmit.durationMs,
         purchaseTime: new Date().toISOString(),
         protocol,
+        expectedExpirationAfter: txToSubmit.previousExpiration,
       };
       addPendingTransaction(pendingClient);
       setPendingClientsFromStorage(
         getPendingTransactions().filter((tx) => tx.status === "pending"),
       );
-      startPolling(txToSubmit.clientId, protocol);
+      startPolling(
+        txToSubmit.clientId,
+        protocol,
+        0,
+        txToSubmit.previousExpiration ?? null,
+      );
     } catch (error) {
       console.error("Transaction error details:", error);
       setErrorModal("Failed to sign and submit transaction");
@@ -674,6 +697,7 @@ const Account = () => {
         newExpiration: newExpirationDate
           ? newExpirationDate.toLocaleString()
           : undefined,
+        previousExpiration: renewingInstanceExpiration?.getTime(),
       });
     } catch (error) {
       console.error("Renew failed:", error);
@@ -1177,6 +1201,11 @@ const Account = () => {
                         isDevicesLoading={wgDevicesLoadingId === instance.id}
                         devicesError={wgDevicesErrorById[instance.id] ?? null}
                         shouldSpinRenew={areAllInstancesExpired}
+                        isRenewing={
+                          isPolling &&
+                          pollingClientId === instance.id &&
+                          instance.status !== "Pending"
+                        }
                         onGetConfig={
                           isWg ? undefined : () => handleGetConfig(instance.id)
                         }

--- a/src/utils/pendingTransactions.ts
+++ b/src/utils/pendingTransactions.ts
@@ -10,6 +10,10 @@ export interface PendingTransaction {
   attempts: number;
   maxAttempts: number;
   protocol: VpnProtocol;
+  // For renewals only: the subscription's expiration (ms) before renewal.
+  // Polling treats the tx as indexed once the expiration exceeds this value.
+  // Undefined for new signups, which instead wait for the client to appear.
+  expectedExpirationAfter?: number;
 }
 
 const STORAGE_KEY = "vpn_pending_transactions";


### PR DESCRIPTION
Fixes #287 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a “Renewing…” spinner on WireGuard subscription cards while a renewal is indexing, and clear it once the new expiration is indexed. Polling now waits for the expiration to advance past its pre-renewal value and restores the renewing state after reloads.

- **Bug Fixes**
  - Updated `useClientPolling` to accept `expectedExpirationAfter` and mark renewals ready only when the indexed expiration increases.
  - Persisted `expectedExpirationAfter` in `pendingTransactions` and passed it from `Account`; pending records are removed only after expiration advances, so the renewing state survives page reloads.
  - `Account` sets `isRenewing` for the matching instance while polling is active.
  - `VpnInstance` shows a small spinner and “Renewing…” when `isRenewing` is true.

<sup>Written for commit 877e528167b3db17c1a16fe6860d3256de39329c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/vpn-frontend/pull/288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer renewal progress handling, including a “Renewing…” status while renewal or buy-time changes are being processed.
  * Improved polling so renewed connections wait for the updated expiration time before showing as ready.

* **Bug Fixes**
  * Fixed readiness detection for renewal flows so connection status updates more reliably after extending service time.
  * Kept existing connection checks intact for standard connection and non-standard protocol flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->